### PR TITLE
Compare push-preview as a boolean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
   release:
     needs: [versioning, build]
     if: needs.versioning.outputs.release-exists == 'false'
-      && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || inputs.push-preview == 'true')
+      && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || inputs.push-preview == true)
     uses: f2calv/gha-workflows/.github/workflows/gha-release-versioning.yml@v1
     permissions:
       contents: write


### PR DESCRIPTION
The `push-preview` input is declared as a boolean but the release condition compared it to the string `'true'`.

GitHub [coerces mismatched types to a number](https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#operators): a boolean `true` becomes `1` and a non-numeric string becomes `NaN`, so the comparison never matched.

Releases on the default branch were unaffected, since the first clause of the condition covers them. It was the preview path that could never fire.

Introduced when `push-preview` was normalised from a string to a boolean without updating the comparison; `dotnet-nuget-test` had the same defect and is fixed alongside.