### PR TITLE
Validate generated YAML against Azure DevOps and fix five generator bugs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,17 @@
 !src/**/*.cs
 !src/**/appsettings*.json
 
+# Debug builds (Dockerfile.Debug) mirror the local sibling repositories into deps/, because a build
+# context cannot reach outside the repository. Release builds never populate it.
+!deps/**
+
+# Re-excluded after the deps allow-list above, which would otherwise pull generated files such as
+# *.AssemblyInfo.cs and *.nuget.g.props into the context and bust the restore layer cache.
+**/bin
+**/obj
+**/.git
+**/.vs
+
 # The test project is never part of the runtime image. Excluding it keeps test
 # edits from busting the restore layer cache.
 **/*.Tests

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Copy to `.env` in the repository root, which is git-ignored. Never commit a populated copy.
+#
+# One variable, holding the raw full-access Personal Access Token exactly as Azure DevOps issued
+# it. No encoding, no quotes, no `<email>:` prefix.
+#
+# Read by `.scripts/Start-AdoMcpServer.ps1`, which launches the `ado` MCP server declared in
+# `.vscode/mcp.json`, and by `.scripts/New-FixtureProject.ps1`. Neither yamlizr nor the test suite
+# reads this file.
+#
+# The MCP server itself wants a variable named PERSONAL_ACCESS_TOKEN containing base64 of
+# "<email>:<pat>", which is neither a personal access token nor something anyone should assemble by
+# hand. The launcher derives it, so that detail stays out of this file.
+#
+# Use the full-access token here. The read-only token the integration tests use belongs in
+# User Secrets under `CasCap:AzureDevOpsOptions:PAT`, not in this file.
+AZURE_DEVOPS_PAT=

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,7 @@ Detailed conventions live in scoped instruction files under `.github/instruction
 | `dotnet.instructions.md` | `**/*.csproj`, `*.slnx`, `Directory.*.props` | Central build/package config, solution format, SDK selection |
 | `github-actions.instructions.md` | workflows / `action.yml` | GitHub Actions naming, YAML, security, GitVersion |
 | `bash.instructions.md` | `**/*.sh` | Bash scripting structure, error handling, logging, testability |
+| `powershell.instructions.md` | `**/*.ps1`, `*.psm1`, `*.psd1` | PowerShell structure, strict mode, error handling, secret safety |
 | `documentation.instructions.md` | `**/*.md` | README consistency and Mermaid diagrams |
 | `configuration.instructions.md` | `**/appsettings*.json` | Options/appsettings synchronization and secret safety |
 

--- a/.github/instructions/powershell.instructions.md
+++ b/.github/instructions/powershell.instructions.md
@@ -1,0 +1,51 @@
+---
+description: 'PowerShell scripting conventions for structure, strict mode, error handling and secret safety.'
+applyTo: '**/*.ps1,**/*.psm1,**/*.psd1'
+---
+
+# PowerShell Scripts
+
+## Structure
+
+- **Shebang**: Open every `.ps1` with `#!/usr/bin/env pwsh` so the script is portable to Linux and macOS. Omit it from `.psm1` and `.psd1`.
+- **Version requirement**: Follow the shebang with `#Requires -Version 7.4`. Windows PowerShell 5.1 is not a target.
+- **Comment-based help**: Every non-trivial script needs `.SYNOPSIS`, `.DESCRIPTION`, one `.PARAMETER` per parameter, at least one `.EXAMPLE`, and `.NOTES` where preconditions such as credential scopes apply.
+- **CmdletBinding and typed parameters**: Declare `[CmdletBinding()]` and a typed `param()` block. Add `SupportsShouldProcess` to any script that writes to a remote system, and gate every write behind `$PSCmdlet.ShouldProcess(...)` so `-WhatIf` is honest.
+- **Location**: Place scripts in the dot-prefixed `.scripts/` folder at the repository root. Top-level developer entry points invoked directly by name, such as `build.ps1` and `clean.ps1`, live at the repository root instead, and have a matching `.sh` sibling where the task is not Windows-specific.
+- **Naming**: `Verb-Noun.ps1` using an approved verb. Check with `Get-Verb`. `Set-` is the correct verb for a create-or-update, not `New-`.
+- **Regions**: Group logical sections with `#region` / `#endregion`.
+- **Invocation guard**: Wrap main execution in `if ($MyInvocation.InvocationName -ne '.')` so the script can be dot-sourced by a test without running.
+
+## Strict Mode
+
+- **Require `Set-StrictMode -Version 3.0`** immediately after `$ErrorActionPreference`. It catches uninitialised variables, missing properties, missing hashtable keys, and array indexes past the end.
+- **Pin the number; never use `Latest`.** `Latest` is a moving target that silently adopts new rules when the PowerShell version changes, so a script that passes today can fail on a runner with a newer build. In PowerShell 7.6 the two are behaviourally identical, which is precisely why pinning costs nothing.
+- Versions above `3.0` are accepted by the parameter but define no additional checks. `3.0` is the strictest meaningful level.
+- Strict mode makes property access on loosely shaped JSON throw. Guard it with `ContainsKey()` on a hashtable, or `PSObject.Properties.Name -contains` on an object, rather than relaxing the mode.
+
+## Error Handling
+
+- Set `$ErrorActionPreference = 'Stop'` immediately after the `param()` block.
+- Set `$PSNativeCommandUseErrorActionPreference = $false` before invoking a native command whose own exit code reporting is sufficient.
+- Wrap main execution in `try` / `catch`, and exit with an explicit code: `0` on success, `1` on failure.
+- `throw` for validation failures inside a function; `Write-Error -ErrorAction Continue` in a top-level catch before exiting.
+- Fail with a message that names the operation and the remedy. An HTTP status alone is not diagnosable.
+
+## Arrays and Shapes
+
+- **Wrap in `@()` whenever a collection leaves an `if`, `switch`, or `foreach`.** A single-element array collapses to a bare object on assignment, which silently serialises as an object instead of an array and is rejected by REST APIs as an empty collection.
+- Type a parameter that must be a collection as `[array]` or `[object[]]`.
+- Do not assume a REST response shape. Handle both a bare array and a `count`/`value` envelope.
+
+## Secrets
+
+- Accept credentials as `[securestring]`, or read them from an environment variable or git-ignored `.env`. Never accept a plain-text credential as a defaulted parameter.
+- Never write a credential, an `Authorization` header, or a value derived from either to any stream, including verbose and debug output.
+- Strip the query string before including a Uri in an error message.
+- Never commit a populated `.env`. Ship a `.env.example` documenting each variable instead.
+
+## Output
+
+- A script whose stdout is consumed by another process, such as an MCP server host, must write nothing to stdout. Send diagnostics to stderr with `[Console]::Error.WriteLine(...)`.
+- Otherwise use `Write-Host` for progress, `Write-Verbose` for detail, and `Write-Warning` for recoverable problems.
+- Do not use emoji in script output.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
       id-token: write #OIDC token for NuGet Trusted Publishing
       contents: read #checkout
       packages: write #push to nuget.pkg.github.com
+    #The action runs the tests before it packs, so a conversion Azure DevOps rejects blocks every
+    #publish. A fork pull request cannot read the token, which leaves the integration tests to skip
+    #themselves rather than fail. The token is never echoed.
+    env:
+      CasCap__AzureDevOpsOptions__PAT: ${{ secrets.AZURE_DEVOPS_PAT }}
+      CasCap__AzureDevOpsOptions__OrganisationUri: ${{ vars.AZURE_DEVOPS_ORGANISATION_URI }}
+      CasCap__AzureDevOpsOptions__Project: ${{ vars.AZURE_DEVOPS_PROJECT }}
+      CasCap__AzureDevOpsOptions__ValidationPipelineId: ${{ vars.AZURE_DEVOPS_VALIDATION_PIPELINE_ID }}
     steps:
       - uses: f2calv/gha-dotnet-nuget@v2
         with:
@@ -66,8 +74,6 @@ jobs:
           push-preview: ${{ inputs.push-preview }}
           version: ${{ needs.versioning.outputs.version }}
           solution-name: yamlizr.Release.slnx
-          #Integration tests need a live Azure DevOps organisation and a token, the rest are credential-free.
-          dotnet-test-args: --filter-not-trait Category=Integration
 
   image:
     uses: f2calv/gha-workflows/.github/workflows/container-image-build.yml@v1

--- a/.gitignore
+++ b/.gitignore
@@ -412,6 +412,7 @@ FodyWeavers.xsd
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+!.vscode/mcp.json
 !.vscode/*.code-snippets
 
 # Local History for Visual Studio Code

--- a/.gitignore
+++ b/.gitignore
@@ -418,6 +418,9 @@ FodyWeavers.xsd
 # Local History for Visual Studio Code
 .history/
 
+# Sibling repositories mirrored in by build.ps1/build.sh for a Dockerfile.Debug build
+/deps/
+
 # Built Visual Studio Code Extensions
 *.vsix
 

--- a/.scripts/New-FixtureDefinitions.ps1
+++ b/.scripts/New-FixtureDefinitions.ps1
@@ -693,6 +693,51 @@ function Set-FixtureBuildDefinition {
         -Uri "$script:ProjectUri/_apis/build/definitions?api-version=$script:ApiVersion"
 }
 
+function Set-FixtureValidationPipeline {
+    <#
+    .SYNOPSIS
+        Creates or updates the YAML pipeline that generated YAML is validated against.
+    .DESCRIPTION
+        The pipeline preview endpoint parses a submitted document without queueing anything, but it
+        needs an existing YAML pipeline to parse against, and that pipeline must be enabled. A
+        disabled one fails the call with DefinitionDisabledException, which is why this is the one
+        fixture left enabled. It has no triggers, and its own YAML is never read because the
+        submitted document replaces it.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$Name)
+
+    $body = @{
+        name                  = $Name
+        path                  = '\'
+        type                  = 'build'
+        quality               = 'definition'
+        queueStatus           = 'enabled'
+        queue                 = @{ id = $script:QueueId }
+        jobAuthorizationScope = 'projectCollection'
+        repository            = $script:RepositoryReference
+        process               = @{ type = 2; yamlFilename = 'azure-pipelines.yml' }
+        triggers              = @()
+    }
+
+    $existing = Get-AdoCollection -Uri "$script:ProjectUri/_apis/build/definitions?name=$([uri]::EscapeDataString($Name))&api-version=$script:ApiVersion" |
+        Select-Object -First 1
+
+    if ($existing) {
+        if (-not $PSCmdlet.ShouldProcess($Name, 'Update validation pipeline')) { return $existing }
+        Write-Host "Updating validation pipeline '$Name'." -ForegroundColor DarkGray
+        $body.id = $existing.id
+        $body.revision = $existing.revision
+        return Invoke-AdoApi -Method Put -Body $body `
+            -Uri "$script:ProjectUri/_apis/build/definitions/$($existing.id)?api-version=$script:ApiVersion"
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Create validation pipeline')) { return $null }
+    Write-Host "Creating validation pipeline '$Name'." -ForegroundColor Cyan
+    return Invoke-AdoApi -Method Post -Body $body `
+        -Uri "$script:ProjectUri/_apis/build/definitions?api-version=$script:ApiVersion"
+}
+
 function Set-FixtureReleaseDefinition {
     <#
     .SYNOPSIS
@@ -1199,6 +1244,7 @@ if ($MyInvocation.InvocationName -ne '.') {
 
         $taskGroups = New-FixtureTaskGroups
         $builds = New-FixtureBuildDefinitions -TaskGroups $taskGroups -VariableGroupId $variableGroupId
+        $validationPipeline = Set-FixtureValidationPipeline -Name "$($script:Prefix)validation"
 
         if ($builds.ContainsKey('Triggers') -and $builds.Triggers) {
             New-FixtureReleaseDefinition -SourceBuildDefinition $builds.Triggers -TaskGroups $taskGroups -VariableGroupId $variableGroupId | Out-Null
@@ -1209,6 +1255,11 @@ if ($MyInvocation.InvocationName -ne '.') {
 
         Write-Host "Fixtures prefixed '$script:Prefix' are up to date in project '$script:ProjectName'." -ForegroundColor Green
         Write-Host "Convert them with: yamlizr --filter $script:Prefix" -ForegroundColor Green
+
+        if ($validationPipeline) {
+            Write-Host "Validate generated YAML against pipeline id $($validationPipeline.id), set CasCap:AzureDevOpsOptions:ValidationPipelineId to it." -ForegroundColor Green
+        }
+
         exit 0
     }
     catch {

--- a/.scripts/New-FixtureDefinitions.ps1
+++ b/.scripts/New-FixtureDefinitions.ps1
@@ -1,0 +1,1220 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+    Creates or updates the yamlizr conversion fixture definitions in an existing Azure DevOps project.
+
+.DESCRIPTION
+    Issue #366 needs a curated set of deliberately awkward classic Build and Release definitions, so
+    the integration tests can prove yamlizr converts a real definition correctly rather than only
+    converting a hand-built one.
+
+    The Azure DevOps MCP server cannot build that fixture. Its only write tool for pipelines,
+    pipelines_write.create_pipeline, creates YAML pipelines, and the fixture needs classic designer
+    definitions, task groups, variable groups and release definitions. This script calls the REST
+    API directly instead, and is the reproducible record of how the fixture was built.
+
+    The fixture shares a project with unrelated definitions, so every object it creates carries a
+    common name prefix. That keeps the fixture identifiable, and it means the conversion can be
+    driven with `yamlizr --filter <prefix>`, which exercises that filter rather than leaving it
+    untested.
+
+    Every operation is an upsert keyed on the object name, so the script is safe to re-run. It
+    creates and updates; it never deletes, and it never touches an object outside the prefix.
+
+    The token this script needs is the full-access one. It is deliberately not the read-only token
+    the integration tests use, which lives in User Secrets under CasCap:AzureDevOpsOptions:PAT.
+
+.PARAMETER OrganisationUri
+    Absolute Uri of the Azure DevOps organisation, for example https://dev.azure.com/contoso.
+
+.PARAMETER Project
+    Name of an existing project to add the fixture definitions to. The script never creates one.
+
+.PARAMETER Prefix
+    Name prefix applied to every object the script creates, and the value to pass to yamlizr's
+    --filter option.
+
+.PARAMETER TemplateDefinition
+    Name of an existing definition whose repository binding the fixtures should copy. Defaults to
+    the first definition in the project.
+
+.PARAMETER Pat
+    Full-access Personal Access Token. When omitted, AZURE_DEVOPS_PAT is read from the environment
+    or from the .env file named by -EnvFile.
+
+.PARAMETER EnvFile
+    Path to the .env file holding AZURE_DEVOPS_PAT. Defaults to .env in the repository root.
+
+.PARAMETER IncludeGates
+    Adds a pre-deployment gate to the release fixture. Off by default because a gate needs a shared
+    work item query, which the project may not have.
+
+.PARAMETER IncludeUnknownTask
+    Adds a step referencing a task GUID that is not installed, to cover the null-reference path in
+    issue #177. Off by default because Azure DevOps may reject the definition outright.
+
+.EXAMPLE
+    ./.scripts/New-FixtureDefinitions.ps1 -OrganisationUri https://dev.azure.com/contoso -Project demo -WhatIf
+
+    Reports every object that would be created or updated, without calling any write API.
+
+.EXAMPLE
+    ./.scripts/New-FixtureDefinitions.ps1 -OrganisationUri https://dev.azure.com/contoso -Project demo
+
+.NOTES
+    Required token scopes: Build (Read & execute), Release (Read, write, execute & manage), Task
+    Groups (Read, create & manage), Variable Groups (Read, create & manage), Project and Team (Read).
+
+    Code is deliberately not required. The repository binding is copied from an existing definition
+    rather than resolved against Azure Repos.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$OrganisationUri,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Project,
+
+    [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    [string]$Prefix = 'yamlizr.test.',
+
+    [Parameter()]
+    [string]$TemplateDefinition,
+
+    [Parameter()]
+    [securestring]$Pat,
+
+    [Parameter()]
+    [string]$EnvFile = (Join-Path $PSScriptRoot '..' '.env'),
+
+    [Parameter()]
+    [switch]$IncludeGates,
+
+    [Parameter()]
+    [switch]$IncludeUnknownTask
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+#region Constants
+
+$script:ApiVersion = '7.1'
+$script:PreviewApiVersion = '7.1-preview.1'
+$script:VariableGroupApiVersion = '7.1-preview.2'
+
+$script:Prefix = $Prefix
+$script:VariableGroupName = "${Prefix}common"
+$script:TaskGroupWithSpaces = "${Prefix}Task Group With Spaces"
+$script:NestedTaskGroupName = "${Prefix}Nested Task Group"
+
+#endregion Constants
+
+#region Connection
+
+function Get-AuthorizationHeader {
+    <#
+    .SYNOPSIS
+        Builds the basic authorization header value, without ever emitting it.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param(
+        [securestring]$Pat,
+        [string]$EnvFile
+    )
+
+    if ($Pat) {
+        $token = [System.Net.NetworkCredential]::new('', $Pat).Password
+    }
+    else {
+        $token = $env:AZURE_DEVOPS_PAT
+
+        if ([string]::IsNullOrWhiteSpace($token) -and (Test-Path -LiteralPath $EnvFile)) {
+            foreach ($line in Get-Content -LiteralPath $EnvFile) {
+                if ($line -match '^\s*AZURE_DEVOPS_PAT\s*=\s*(.+?)\s*$') {
+                    $token = $Matches[1].Trim("'", '"')
+                    break
+                }
+            }
+        }
+    }
+
+    if ([string]::IsNullOrWhiteSpace($token)) {
+        throw "No credential available. Pass -Pat, or set AZURE_DEVOPS_PAT in '$EnvFile'. See .env.example."
+    }
+
+    return 'Basic ' + [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes(":$token"))
+}
+
+function Get-VsrmUri {
+    <#
+    .SYNOPSIS
+        Maps an organisation Uri onto the Release Management host that serves release definitions.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([string]$OrganisationUri)
+
+    $trimmed = $OrganisationUri.TrimEnd('/')
+
+    if ($trimmed -match '^https://dev\.azure\.com/') {
+        return $trimmed -replace '^https://dev\.azure\.com/', 'https://vsrm.dev.azure.com/'
+    }
+
+    if ($trimmed -match '^https://[^.]+\.visualstudio\.com') {
+        return $trimmed -replace '^https://([^.]+)\.visualstudio\.com', 'https://$1.vsrm.visualstudio.com'
+    }
+
+    throw 'Unrecognised organisation Uri. Expected https://dev.azure.com/<org> or https://<org>.visualstudio.com.'
+}
+
+function Invoke-AdoApi {
+    <#
+    .SYNOPSIS
+        Calls an Azure DevOps REST endpoint, reporting failures without echoing the credential.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Uri,
+
+        [ValidateSet('Get', 'Post', 'Put', 'Patch', 'Delete')]
+        [string]$Method = 'Get',
+
+        [object]$Body
+    )
+
+    $arguments = @{
+        Uri         = $Uri
+        Method      = $Method
+        Headers     = @{ Authorization = $script:AuthorizationHeader; Accept = 'application/json' }
+        ContentType = 'application/json; charset=utf-8'
+        ErrorAction = 'Stop'
+    }
+
+    if ($null -ne $Body) {
+        $arguments.Body = [Text.Encoding]::UTF8.GetBytes(($Body | ConvertTo-Json -Depth 32))
+    }
+
+    try {
+        $response = Invoke-WebRequest @arguments
+    }
+    catch {
+        # The Uri and the request body never carry the token, so both are safe to report.
+        $safeUri = ($Uri -split '\?')[0]
+        $detail = if ($_.ErrorDetails) { " $($_.ErrorDetails.Message)" } else { '' }
+        $status = if ($_.Exception.Response) { [int]$_.Exception.Response.StatusCode } else { 0 }
+
+        # Azure DevOps answers a missing scope with a sign-in challenge, which reads like a bad token.
+        $hint = if ($status -in 401, 203, 403) {
+            " The token authenticated but lacks the scope for this endpoint. Check the scopes listed in .scripts/README.md."
+        }
+        else { '' }
+
+        throw "Azure DevOps $Method $safeUri failed: $($_.Exception.Message).$detail$hint"
+    }
+
+    $content = $response.Content
+    if ([string]::IsNullOrWhiteSpace($content)) { return $null }
+
+    $trimmed = $content.TrimStart()
+    if (-not ($trimmed.StartsWith('{') -or $trimmed.StartsWith('['))) {
+        # A sign-in page arrives as HTML with a 200, which is how a missing scope usually presents.
+        throw "Azure DevOps $Method $(($Uri -split '\?')[0]) returned $($response.StatusCode) with a non-JSON body, which normally means the token lacks the scope for this endpoint."
+    }
+
+    # -AsHashtable is not optional. The task catalogue carries a property with an empty name, which
+    # the object parser rejects outright, and it gives one predictable shape for every response.
+    return $content | ConvertFrom-Json -AsHashtable
+}
+
+function Get-AdoCollection {
+    <#
+    .SYNOPSIS
+        Returns the items of a list endpoint.
+    .DESCRIPTION
+        Azure DevOps is not consistent about this. Most endpoints wrap results in a count/value
+        envelope, but some, distributedtask/tasks among them, return a bare array. Reading .value
+        blindly fails on the second shape under Set-StrictMode.
+    #>
+    [CmdletBinding()]
+    [OutputType([array])]
+    param([Parameter(Mandatory)][string]$Uri)
+
+    $response = Invoke-AdoApi -Uri $Uri
+
+    if ($null -eq $response) { return @() }
+    if ($response -is [System.Collections.IDictionary]) {
+        if ($response.ContainsKey('value')) { return @($response['value']) }
+        return @($response)
+    }
+
+    return @($response)
+}
+
+#endregion Connection
+
+#region Discovery
+
+function Get-FixtureProject {
+    <#
+    .SYNOPSIS
+        Returns the project the fixtures are added to, which must already exist.
+    #>
+    [CmdletBinding()]
+    param([string]$Name)
+
+    $projects = Get-AdoCollection -Uri "$script:OrgUri/_apis/projects?api-version=$script:ApiVersion"
+    $existing = $projects | Where-Object { $_.name -eq $Name } | Select-Object -First 1
+
+    if (-not $existing) {
+        throw "Project '$Name' was not found. Available projects: $(($projects.name | Sort-Object) -join ', ')."
+    }
+
+    return $existing
+}
+
+function Get-FixtureRepositoryReference {
+    <#
+    .SYNOPSIS
+        Returns the repository binding the fixture definitions should use, copied from an existing one.
+    .DESCRIPTION
+        A classic Build definition must name a repository, and the binding for a GitHub repository
+        carries a service connection id plus a page of provider metadata that cannot be reconstructed
+        from a repository name. Copying it from a definition that already builds keeps the fixtures
+        pointing somewhere real, and keeps the Code scope off the token, which enumerating Azure
+        Repos would otherwise demand.
+
+        Nothing is ever pushed to the borrowed repository. The fixture definitions are never queued.
+    #>
+    [CmdletBinding()]
+    param([string]$TemplateDefinition)
+
+    $references = Get-AdoCollection -Uri "$script:ProjectUri/_apis/build/definitions?api-version=$script:ApiVersion"
+
+    if (-not $references) {
+        throw "Project '$script:ProjectName' has no build definition to copy a repository binding from."
+    }
+
+    $chosen = $null
+    if ($TemplateDefinition) {
+        $chosen = $references | Where-Object { $_.name -eq $TemplateDefinition } | Select-Object -First 1
+        if (-not $chosen) {
+            throw "Template definition '$TemplateDefinition' was not found in project '$script:ProjectName'."
+        }
+    }
+
+    # Prefer a definition that is not itself a fixture, so a re-run does not copy from its own output.
+    if (-not $chosen) {
+        $chosen = $references | Where-Object { -not $_.name.StartsWith($script:Prefix, [StringComparison]::OrdinalIgnoreCase) } | Select-Object -First 1
+    }
+    if (-not $chosen) { $chosen = $references | Select-Object -First 1 }
+
+    $full = Invoke-AdoApi -Uri "$script:ProjectUri/_apis/build/definitions/$($chosen.id)?api-version=$script:ApiVersion"
+
+    if (-not $full.ContainsKey('repository') -or -not $full['repository']) {
+        throw "Definition '$($chosen.name)' has no repository binding to copy."
+    }
+
+    Write-Host "Copying the repository binding from '$($chosen.name)' ($($full.repository.type))." -ForegroundColor DarkGray
+
+    return $full.repository
+}
+
+function Get-HostedQueue {
+    <#
+    .SYNOPSIS
+        Returns the Microsoft hosted agent queue the fixture definitions target.
+    #>
+    [CmdletBinding()]
+    param()
+
+    $queues = Get-AdoCollection -Uri "$script:ProjectUri/_apis/distributedtask/queues?api-version=$script:PreviewApiVersion"
+
+    $queue = $queues | Where-Object { $_.name -eq 'Azure Pipelines' } | Select-Object -First 1
+    if (-not $queue) { $queue = $queues | Select-Object -First 1 }
+    if (-not $queue) { throw 'The fixture project has no agent queue.' }
+
+    return $queue
+}
+
+function Get-InstalledTaskMap {
+    <#
+    .SYNOPSIS
+        Builds a name to identifier map of the tasks installed in the organisation.
+    .DESCRIPTION
+        Task GUIDs are resolved at run time rather than hard coded, so the script keeps working when
+        an organisation carries a different set of installed extensions.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param()
+
+    $tasks = Get-AdoCollection -Uri "$script:OrgUri/_apis/distributedtask/tasks?api-version=$script:PreviewApiVersion"
+
+    # The catalogue is not uniform, so anything missing a name, id or version is skipped rather than
+    # allowed to throw under Set-StrictMode.
+    $usable = $tasks | Where-Object {
+        $_.ContainsKey('name') -and $_.ContainsKey('id') -and $_.ContainsKey('version') -and $_['version']
+    }
+
+    # Indexed by both name and friendlyName, because the two differ for several in-box tasks.
+    $map = @{}
+    foreach ($group in $usable | Group-Object -Property { $_['name'] }) {
+        $newest = $group.Group |
+            Sort-Object -Property { [int]$_['version']['major'] }, { [int]$_['version']['minor'] } |
+            Select-Object -Last 1
+
+        $entry = @{ Id = $newest['id']; VersionSpec = "$($newest['version']['major']).*" }
+        $map[$group.Name] = $entry
+
+        $friendly = if ($newest.ContainsKey('friendlyName')) { $newest['friendlyName'] } else { $null }
+        if ($friendly -and -not $map.ContainsKey($friendly)) { $map[$friendly] = $entry }
+    }
+
+    if ($map.Count -eq 0) { throw 'No installed tasks were resolved, so no fixture step can be built.' }
+
+    return $map
+}
+
+#endregion Discovery
+
+#region Builders
+
+function New-TaskStep {
+    <#
+    .SYNOPSIS
+        Builds one classic step referencing an installed task.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][string]$TaskName,
+        [Parameter(Mandatory)][string]$DisplayName,
+        [hashtable]$Inputs = @{},
+        [bool]$Enabled = $true,
+        [bool]$ContinueOnError = $false,
+        [bool]$AlwaysRun = $false,
+        [string]$Condition = 'succeeded()'
+    )
+
+    if (-not $script:Tasks.ContainsKey($TaskName)) {
+        throw "Task '$TaskName' is not installed in this organisation, so the fixture cannot reference it."
+    }
+
+    $task = $script:Tasks[$TaskName]
+
+    return @{
+        environment      = @{}
+        enabled          = $Enabled
+        continueOnError  = $ContinueOnError
+        alwaysRun        = $AlwaysRun
+        displayName      = $DisplayName
+        timeoutInMinutes = 0
+        condition        = $Condition
+        task             = @{ id = $task.Id; versionSpec = $task.VersionSpec; definitionType = 'task' }
+        inputs           = $Inputs
+    }
+}
+
+function New-TaskGroupStep {
+    <#
+    .SYNOPSIS
+        Builds one classic step referencing a task group rather than a task.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][string]$TaskGroupId,
+        [Parameter(Mandatory)][string]$DisplayName,
+        [hashtable]$Inputs = @{},
+        [string]$VersionSpec = '1.*',
+        [bool]$Enabled = $true,
+        [string]$Condition = 'succeeded()'
+    )
+
+    return @{
+        environment      = @{}
+        enabled          = $Enabled
+        continueOnError  = $false
+        alwaysRun        = $false
+        displayName      = $DisplayName
+        timeoutInMinutes = 0
+        condition        = $Condition
+        task             = @{ id = $TaskGroupId; versionSpec = $VersionSpec; definitionType = 'metaTask' }
+        inputs           = $Inputs
+    }
+}
+
+function ConvertTo-WorkflowTask {
+    <#
+    .SYNOPSIS
+        Rewrites a build step into the shape a release deploy phase expects.
+    .DESCRIPTION
+        The two are not interchangeable. A release workflow task carries taskId, version, name and
+        definitionType at the top level, where a build step nests them under task.id,
+        task.versionSpec, displayName and task.definitionType.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param([Parameter(Mandatory)][hashtable]$Step)
+
+    return @{
+        environment      = @{}
+        taskId           = $Step.task.id
+        version          = $Step.task.versionSpec
+        name             = $Step.displayName
+        refName          = ''
+        enabled          = $Step.enabled
+        alwaysRun        = $Step.alwaysRun
+        continueOnError  = $Step.continueOnError
+        timeoutInMinutes = $Step.timeoutInMinutes
+        definitionType   = $Step.task.definitionType
+        overrideInputs   = @{}
+        condition        = $Step.condition
+        inputs           = $Step.inputs
+    }
+}
+
+function New-AgentPhase {
+    <#
+    .SYNOPSIS
+        Builds an agent phase, optionally depending on earlier phases.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$RefName,
+        [Parameter(Mandatory)][array]$Steps,
+        [string[]]$DependsOn = @(),
+        [string]$Condition = 'succeeded()'
+    )
+
+    $phase = @{
+        name                      = $Name
+        refName                   = $RefName
+        condition                 = $Condition
+        jobAuthorizationScope     = 'projectCollection'
+        jobCancelTimeoutInMinutes = 1
+        steps                     = $Steps
+        target                    = @{
+            type                         = 1
+            executionOptions             = @{ type = 0 }
+            allowScriptsAuthAccessOption = $false
+            queue                        = @{ id = $script:QueueId }
+            demands                      = @()
+        }
+    }
+
+    if ($DependsOn.Count -gt 0) {
+        $phase.dependencies = @($DependsOn | ForEach-Object { @{ scope = $_; event = 'Completed' } })
+    }
+
+    return $phase
+}
+
+function New-ServerPhase {
+    <#
+    .SYNOPSIS
+        Builds an agentless phase, which yamlizr currently skips.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$RefName,
+        [Parameter(Mandatory)][array]$Steps,
+        [string[]]$DependsOn = @()
+    )
+
+    $phase = @{
+        name                      = $Name
+        refName                   = $RefName
+        condition                 = 'succeeded()'
+        # Required on a server phase too, even though it has no agent to scope.
+        jobAuthorizationScope     = 'projectCollection'
+        jobCancelTimeoutInMinutes = 1
+        steps                     = $Steps
+        target                    = @{ type = 2; executionOptions = @{ type = 0 } }
+    }
+
+    if ($DependsOn.Count -gt 0) {
+        $phase.dependencies = @($DependsOn | ForEach-Object { @{ scope = $_; event = 'Completed' } })
+    }
+
+    return $phase
+}
+
+#endregion Builders
+
+#region Upserts
+
+function Set-FixtureVariableGroup {
+    <#
+    .SYNOPSIS
+        Creates or updates the shared variable group the fixture definitions link.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param([string]$Name)
+
+    $body = @{
+        name                          = $Name
+        description                   = 'Fixture variables. No value here is a real credential.'
+        type                          = 'Vsts'
+        variables                     = @{
+            'fixture.group.plain'  = @{ value = 'group-plain-value' }
+            'fixture.group.spaced' = @{ value = 'value with spaces and a $(fixture.plain) reference' }
+            'fixture.group.secret' = @{ value = 'placeholder-not-a-credential'; isSecret = $true }
+        }
+        variableGroupProjectReferences = @(@{
+                name             = $Name
+                description      = 'Fixture variables.'
+                projectReference = @{ id = $script:ProjectId; name = $script:ProjectName }
+            })
+    }
+
+    $existing = Get-AdoCollection -Uri "$script:ProjectUri/_apis/distributedtask/variablegroups?groupName=$([uri]::EscapeDataString($Name))&api-version=$script:VariableGroupApiVersion" |
+        Select-Object -First 1
+
+    if ($existing) {
+        if (-not $PSCmdlet.ShouldProcess($Name, 'Update variable group')) { return $existing }
+        Write-Host "Updating variable group '$Name'." -ForegroundColor DarkGray
+        return Invoke-AdoApi -Method Put -Body $body `
+            -Uri "$script:ProjectUri/_apis/distributedtask/variablegroups/$($existing.id)?api-version=$script:VariableGroupApiVersion"
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Create variable group')) { return $null }
+    Write-Host "Creating variable group '$Name'." -ForegroundColor Cyan
+    return Invoke-AdoApi -Method Post -Body $body `
+        -Uri "$script:ProjectUri/_apis/distributedtask/variablegroups?api-version=$script:VariableGroupApiVersion"
+}
+
+function Set-FixtureTaskGroup {
+    <#
+    .SYNOPSIS
+        Creates or updates a task group by name.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Description,
+        [Parameter(Mandatory)][array]$Tasks,
+        [array]$Inputs = @()
+    )
+
+    $body = @{
+        name               = $Name
+        friendlyName       = $Name
+        description        = $Description
+        author             = 'yamlizr fixtures'
+        category           = 'Build'
+        iconUrl            = ''
+        instanceNameFormat = "$Name"
+        runsOn             = @('Agent', 'DeploymentGroup')
+        inputs             = $Inputs
+        tasks              = $Tasks
+        version            = @{ major = 1; minor = 0; patch = 0; isTest = $false }
+    }
+
+    $existing = Get-AdoCollection -Uri "$script:ProjectUri/_apis/distributedtask/taskgroups?api-version=$script:PreviewApiVersion" |
+        Where-Object { $_.name -eq $Name } |
+        Select-Object -First 1
+
+    if ($existing) {
+        if (-not $PSCmdlet.ShouldProcess($Name, 'Update task group')) { return $existing }
+        Write-Host "Updating task group '$Name'." -ForegroundColor DarkGray
+        $body.id = $existing.id
+        $body.revision = $existing.revision
+        $body.version = $existing.version
+        return Invoke-AdoApi -Method Put -Body $body `
+            -Uri "$script:ProjectUri/_apis/distributedtask/taskgroups?api-version=$script:PreviewApiVersion"
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Create task group')) { return $null }
+    Write-Host "Creating task group '$Name'." -ForegroundColor Cyan
+    return Invoke-AdoApi -Method Post -Body $body `
+        -Uri "$script:ProjectUri/_apis/distributedtask/taskgroups?api-version=$script:PreviewApiVersion"
+}
+
+function Set-FixtureBuildDefinition {
+    <#
+    .SYNOPSIS
+        Creates or updates a classic Build definition by name.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][array]$Phases,
+        [hashtable]$Variables = @{},
+        [int[]]$VariableGroupIds = @(),
+        [array]$Triggers = @()
+    )
+
+    $body = @{
+        name                  = $Name
+        path                  = '\'
+        type                  = 'build'
+        quality               = 'definition'
+        # The fixtures carry real triggers against a real repository, so they must never be queueable.
+        queueStatus           = 'disabled'
+        queue                 = @{ id = $script:QueueId }
+        jobAuthorizationScope = 'projectCollection'
+        jobTimeoutInMinutes   = 60
+        repository            = $script:RepositoryReference
+        process               = @{ type = 1; phases = $Phases }
+        variables             = $Variables
+        variableGroups        = @($VariableGroupIds | ForEach-Object { @{ id = $_ } })
+        triggers              = $Triggers
+        retentionRules        = @()
+    }
+
+    $existing = Get-AdoCollection -Uri "$script:ProjectUri/_apis/build/definitions?name=$([uri]::EscapeDataString($Name))&api-version=$script:ApiVersion" |
+        Select-Object -First 1
+
+    if ($existing) {
+        if (-not $PSCmdlet.ShouldProcess($Name, 'Update build definition')) { return $existing }
+        Write-Host "Updating build definition '$Name'." -ForegroundColor DarkGray
+        $body.id = $existing.id
+        $body.revision = $existing.revision
+        return Invoke-AdoApi -Method Put -Body $body `
+            -Uri "$script:ProjectUri/_apis/build/definitions/$($existing.id)?api-version=$script:ApiVersion"
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Create build definition')) { return $null }
+    Write-Host "Creating build definition '$Name'." -ForegroundColor Cyan
+    return Invoke-AdoApi -Method Post -Body $body `
+        -Uri "$script:ProjectUri/_apis/build/definitions?api-version=$script:ApiVersion"
+}
+
+function Set-FixtureReleaseDefinition {
+    <#
+    .SYNOPSIS
+        Creates or updates a classic Release definition by name.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][array]$Environments,
+        [array]$Artifacts = @(),
+        [array]$Triggers = @(),
+        [hashtable]$Variables = @{},
+        [int[]]$VariableGroupIds = @()
+    )
+
+    $body = @{
+        name              = $Name
+        path              = '\'
+        releaseNameFormat = 'Release-$(rev:r)'
+        description       = 'yamlizr conversion fixture. Never deployed.'
+        environments      = $Environments
+        artifacts         = $Artifacts
+        triggers          = $Triggers
+        variables         = $Variables
+        variableGroups    = $VariableGroupIds
+        properties        = @{}
+        tags              = @()
+    }
+
+    $existing = Get-AdoCollection -Uri "$script:VsrmProjectUri/_apis/release/definitions?searchText=$([uri]::EscapeDataString($Name))&api-version=$script:ApiVersion" |
+        Where-Object { $_.name -eq $Name } |
+        Select-Object -First 1
+
+    if ($existing) {
+        if (-not $PSCmdlet.ShouldProcess($Name, 'Update release definition')) { return $existing }
+        Write-Host "Updating release definition '$Name'." -ForegroundColor DarkGray
+        $current = Invoke-AdoApi -Uri "$script:VsrmProjectUri/_apis/release/definitions/$($existing.id)?api-version=$script:ApiVersion"
+        $body.id = $current.id
+        $body.revision = $current.revision
+        return Invoke-AdoApi -Method Put -Body $body `
+            -Uri "$script:VsrmProjectUri/_apis/release/definitions/$($current.id)?api-version=$script:ApiVersion"
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Create release definition')) { return $null }
+    Write-Host "Creating release definition '$Name'." -ForegroundColor Cyan
+    return Invoke-AdoApi -Method Post -Body $body `
+        -Uri "$script:VsrmProjectUri/_apis/release/definitions?api-version=$script:ApiVersion"
+}
+
+#endregion Upserts
+
+#region Fixtures
+
+$script:MultiLineBash = @'
+set -euo pipefail
+
+echo "First line of a multi-line script."
+echo "Second line, which must survive as a literal block scalar."
+
+for candidate in one two three; do
+  echo "candidate: ${candidate}"
+done
+
+if [ -n "${BUILD_BUILDID:-}" ]; then
+  echo "build ${BUILD_BUILDID}"
+fi
+'@
+
+$script:MultiLinePowerShell = @'
+$ErrorActionPreference = 'Stop'
+
+Write-Host 'A multi-line PowerShell script.'
+Write-Host "Trailing whitespace and a colon: value must not break the emitter."
+
+@('alpha', 'beta') | ForEach-Object {
+    Write-Host "item: $_"
+}
+'@
+
+function New-FixtureTaskGroups {
+    <#
+    .SYNOPSIS
+        Creates the leaf task group and the nested task group that calls it.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+
+    $leafInputs = @(
+        @{ name = 'greeting'; label = 'Greeting'; defaultValue = 'hello from the default'; required = $false; type = 'string'; helpMarkDown = 'Has a default so an overriding step can be told apart.'; groupName = '' }
+        @{ name = 'iterations'; label = 'Iterations'; defaultValue = '3'; required = $false; type = 'string'; helpMarkDown = ''; groupName = '' }
+        @{ name = 'unusedByCaller'; label = 'Unused by caller'; defaultValue = 'never overridden'; required = $false; type = 'string'; helpMarkDown = ''; groupName = '' }
+    )
+
+    $leafTasks = @(
+        New-TaskStep -TaskName 'Bash' -DisplayName 'Multi-line bash inside a task group' -Inputs @{
+            targetType = 'inline'
+            script     = "echo `"`$(greeting)`"`n" + $script:MultiLineBash
+        }
+        New-TaskStep -TaskName 'CmdLine' -DisplayName 'Disabled step inside a task group' -Enabled $false -Inputs @{
+            script = 'echo This step is disabled and must be reported as such.'
+        }
+    )
+
+    $leaf = Set-FixtureTaskGroup -Name $script:TaskGroupWithSpaces -Description 'Name contains spaces, referenced by more than one definition.' -Tasks $leafTasks -Inputs $leafInputs
+    if (-not $leaf) { return $null }
+
+    $nestedTasks = @(
+        New-TaskGroupStep -TaskGroupId $leaf.id -DisplayName 'Nested call into the spaced task group' -Inputs @{
+            greeting       = '$(outerGreeting)'
+            iterations     = '2'
+            unusedByCaller = 'never overridden'
+        }
+        New-TaskStep -TaskName 'PowerShell' -DisplayName 'Multi-line PowerShell after the nested call' -Inputs @{
+            targetType = 'inline'
+            script     = $script:MultiLinePowerShell
+        }
+    )
+
+    $nestedInputs = @(
+        @{ name = 'outerGreeting'; label = 'Outer greeting'; defaultValue = 'hello from the outer default'; required = $false; type = 'string'; helpMarkDown = ''; groupName = '' }
+    )
+
+    $nested = Set-FixtureTaskGroup -Name $script:NestedTaskGroupName -Description 'Calls another task group, to cover recursive expansion.' -Tasks $nestedTasks -Inputs $nestedInputs
+
+    return @{ Leaf = $leaf; Nested = $nested }
+}
+
+function New-FixtureBuildDefinitions {
+    <#
+    .SYNOPSIS
+        Creates every classic Build definition in the fixture.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [hashtable]$TaskGroups,
+        [int]$VariableGroupId
+    )
+
+    $created = @{}
+
+    # Phase-to-phase dependencies, including a fan-in.
+    $created.MultiPhase = Set-FixtureBuildDefinition -Name "$($script:Prefix)multi-phase" -Phases @(
+        New-AgentPhase -Name 'Phase one' -RefName 'Phase_1' -Steps @(
+            New-TaskStep -TaskName 'CmdLine' -DisplayName 'Single line' -Inputs @{ script = 'echo phase one' }
+        )
+        New-AgentPhase -Name 'Phase two' -RefName 'Phase_2' -DependsOn @('Phase_1') -Steps @(
+            New-TaskStep -TaskName 'Bash' -DisplayName 'Depends on phase one' -Inputs @{ targetType = 'inline'; script = 'echo phase two' }
+        )
+        New-AgentPhase -Name 'Phase three, fan-in' -RefName 'Phase_3' -DependsOn @('Phase_1', 'Phase_2') -Condition 'succeededOrFailed()' -Steps @(
+            New-TaskStep -TaskName 'Bash' -DisplayName 'Runs even when an earlier phase failed' -AlwaysRun $true -Condition 'succeededOrFailed()' -Inputs @{ targetType = 'inline'; script = 'echo phase three' }
+        )
+    )
+
+    # An agentless phase, which yamlizr skips, next to an agent phase which it does not.
+    $created.ServerPhase = Set-FixtureBuildDefinition -Name "$($script:Prefix)server-phase" -Phases @(
+        New-AgentPhase -Name 'Agent work' -RefName 'Phase_1' -Steps @(
+            New-TaskStep -TaskName 'CmdLine' -DisplayName 'Agent step' -Inputs @{ script = 'echo agent' }
+        )
+        New-ServerPhase -Name 'Agentless wait' -RefName 'Phase_2' -DependsOn @('Phase_1') -Steps @(
+            New-TaskStep -TaskName 'Delay' -DisplayName 'Delay' -Inputs @{ delayForMinutes = '0' }
+        )
+    )
+
+    # Literal block scalar rendering.
+    $created.MultiLine = Set-FixtureBuildDefinition -Name "$($script:Prefix)multiline-scripts" -Phases @(
+        New-AgentPhase -Name 'Scripts' -RefName 'Phase_1' -Steps @(
+            New-TaskStep -TaskName 'Bash' -DisplayName 'Multi-line bash' -Inputs @{ targetType = 'inline'; script = $script:MultiLineBash }
+            New-TaskStep -TaskName 'PowerShell' -DisplayName 'Multi-line PowerShell' -Inputs @{ targetType = 'inline'; script = $script:MultiLinePowerShell }
+            New-TaskStep -TaskName 'CmdLine' -DisplayName 'Multi-line cmd with trailing blank line' -Inputs @{ script = "echo one`necho two`n`n" }
+            New-TaskStep -TaskName 'Bash' -DisplayName 'Script that is only whitespace' -Inputs @{ targetType = 'inline'; script = "   `n   `n" }
+        )
+    )
+
+    # Task groups, including a nested one, an override, and a disabled task group call.
+    if ($TaskGroups -and $TaskGroups.Leaf -and $TaskGroups.Nested) {
+        $created.TaskGroups = Set-FixtureBuildDefinition -Name "$($script:Prefix)task-groups" -Phases @(
+            New-AgentPhase -Name 'Task groups' -RefName 'Phase_1' -Steps @(
+                New-TaskGroupStep -TaskGroupId $TaskGroups.Leaf.id -DisplayName 'Spaced task group, defaults kept' -Inputs @{
+                    greeting       = 'hello from the default'
+                    iterations     = '3'
+                    unusedByCaller = 'never overridden'
+                }
+                New-TaskGroupStep -TaskGroupId $TaskGroups.Leaf.id -DisplayName 'Spaced task group, defaults overridden' -Inputs @{
+                    greeting       = 'overridden by the caller'
+                    iterations     = '7'
+                    unusedByCaller = 'never overridden'
+                }
+                New-TaskGroupStep -TaskGroupId $TaskGroups.Nested.id -DisplayName 'Nested task group' -Inputs @{
+                    outerGreeting = 'outer override'
+                }
+                New-TaskGroupStep -TaskGroupId $TaskGroups.Leaf.id -DisplayName 'Disabled task group call' -Enabled $false -Inputs @{
+                    greeting       = 'never runs'
+                    iterations     = '1'
+                    unusedByCaller = 'never overridden'
+                }
+            )
+        )
+    }
+
+    # Triggers, variables and a linked variable group.
+    $triggers = @(
+        @{
+            triggerType                  = 'continuousIntegration'
+            branchFilters                = @('+refs/heads/main', '-refs/heads/experimental/*')
+            pathFilters                  = @('+/src', '-/docs')
+            batchChanges                 = $true
+            maxConcurrentBuildsPerBranch = 1
+            settingsSourceType           = 1
+        }
+        @{
+            triggerType                          = 'pullRequest'
+            branchFilters                        = @('+refs/heads/main', '+refs/heads/release/*')
+            pathFilters                          = @('+/src')
+            forks                                = @{ enabled = $false; allowSecrets = $false }
+            isCommentRequiredForPullRequest      = $false
+            requireCommentsForNonTeamMembersOnly = $false
+            settingsSourceType                   = 1
+        }
+        @{
+            triggerType = 'schedule'
+            schedules   = @(@{
+                    branchFilters           = @('+refs/heads/main')
+                    timeZoneId              = 'UTC'
+                    startHours              = 3
+                    startMinutes            = 30
+                    # Flags enum, 31 is Monday through Friday.
+                    daysToBuild             = 31
+                    scheduleJobId           = [guid]::Empty.ToString()
+                    scheduleOnlyWithChanges = $true
+                })
+        }
+    )
+
+    $variables = @{
+        'fixture.plain'          = @{ value = 'definition-scoped value'; allowOverride = $false }
+        'fixture.settableAtQueue' = @{ value = 'queue-time default'; allowOverride = $true }
+        'fixture.secret'         = @{ value = 'placeholder-not-a-credential'; isSecret = $true; allowOverride = $false }
+        'fixture.withReference'  = @{ value = 'prefix-$(fixture.plain)-suffix'; allowOverride = $false }
+    }
+
+    $created.Triggers = Set-FixtureBuildDefinition -Name "$($script:Prefix)triggers-and-variables" `
+        -Variables $variables `
+        -VariableGroupIds @($VariableGroupId) `
+        -Triggers $triggers `
+        -Phases @(
+        New-AgentPhase -Name 'Report variables' -RefName 'Phase_1' -Steps @(
+            New-TaskStep -TaskName 'Bash' -DisplayName 'Echo variables' -Inputs @{
+                targetType = 'inline'
+                script     = 'echo "$(fixture.plain) $(fixture.group.plain)"'
+            }
+            New-TaskStep -TaskName 'PublishBuildArtifacts' -DisplayName 'Publish drop' -Inputs @{
+                PathtoPublish = '$(Build.ArtifactStagingDirectory)'
+                ArtifactName  = 'drop'
+                publishLocation = 'Container'
+            }
+        )
+    )
+
+    if ($IncludeUnknownTask) {
+        Write-Host 'Adding the unknown task fixture. Azure DevOps may reject this.' -ForegroundColor Yellow
+        $unknown = @{
+            environment      = @{}
+            enabled          = $true
+            continueOnError  = $false
+            alwaysRun        = $false
+            displayName      = 'Step from an extension that is not installed'
+            timeoutInMinutes = 0
+            condition        = 'succeeded()'
+            # Deliberately not a real task, to cover the null path reported in issue #177.
+            task             = @{ id = '00000000-0000-0000-0000-0000000f0177'; versionSpec = '1.*'; definitionType = 'task' }
+            inputs           = @{ someInput = 'value' }
+        }
+
+        try {
+            $created.UnknownTask = Set-FixtureBuildDefinition -Name "$($script:Prefix)uninstalled-extension" -Phases @(
+                New-AgentPhase -Name 'Uninstalled extension' -RefName 'Phase_1' -Steps @($unknown)
+            )
+        }
+        catch {
+            Write-Warning "Azure DevOps rejected the unknown task fixture, so it was skipped: $($_.Exception.Message)"
+        }
+    }
+
+    return $created
+}
+
+function New-FixtureReleaseDefinition {
+    <#
+    .SYNOPSIS
+        Creates the multi-stage release fixture, with approvals, artifacts and stage dependencies.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]$SourceBuildDefinition,
+        [hashtable]$TaskGroups,
+        [int]$VariableGroupId
+    )
+
+    $artifactAlias = 'fixture-drop'
+
+    $artifacts = @(@{
+            alias               = $artifactAlias
+            type                = 'Build'
+            sourceId            = "$script:ProjectId`:$($SourceBuildDefinition.id)"
+            isPrimary           = $true
+            isRetained          = $false
+            definitionReference = @{
+                project                = @{ id = $script:ProjectId; name = $script:ProjectName }
+                definition             = @{ id = "$($SourceBuildDefinition.id)"; name = $SourceBuildDefinition.name }
+                defaultVersionType     = @{ id = 'latestType'; name = 'Latest' }
+                defaultVersionBranch   = @{ id = ''; name = '' }
+                defaultVersionSpecific = @{ id = ''; name = '' }
+                defaultVersionTags     = @{ id = ''; name = '' }
+                IsMultiDefinitionType  = @{ id = 'False'; name = 'False' }
+            }
+        })
+
+    $gates = @{ id = 0; gatesOptions = $null; gates = @() }
+    if ($IncludeGates) {
+        $sharedQuery = Get-FixtureSharedQuery
+        if ($sharedQuery) {
+            $gates = @{
+                id           = 0
+                gatesOptions = @{ isEnabled = $true; timeout = 60; samplingInterval = 5; stabilizationTime = 0; minimumSuccessDuration = 0 }
+                gates        = @(@{
+                        tasks = @(New-TaskStep -TaskName 'queryWorkItems' -DisplayName 'Query work items gate' -Inputs @{
+                                queryId      = $sharedQuery.id
+                                maxThreshold = '0'
+                                minThreshold = '0'
+                            })
+                    })
+            }
+        }
+        else {
+            Write-Warning 'No shared work item query found, so the release fixture has no gate.'
+        }
+    }
+
+    function New-Environment {
+        param(
+            [string]$Name,
+            [int]$Rank,
+            [array]$Tasks,
+            [bool]$ManualApproval,
+            [string]$AfterEnvironment,
+            [hashtable]$Variables = @{},
+            [hashtable]$PreDeploymentGates = @{ id = 0; gatesOptions = $null; gates = @() }
+        )
+
+        $conditions = if ($AfterEnvironment) {
+            # conditionType 2 is "after stage", value 4 is "succeeded".
+            @(@{ name = $AfterEnvironment; conditionType = 2; value = '4' })
+        }
+        else {
+            @(@{ name = 'ReleaseStarted'; conditionType = 1; value = '' })
+        }
+
+        $preApprovals = if ($ManualApproval) {
+            @(@{ rank = 1; isAutomated = $false; isNotificationOn = $true; approver = @{ id = $script:AuthenticatedUserId }; id = 0 })
+        }
+        else {
+            @(@{ rank = 1; isAutomated = $true; isNotificationOn = $false; id = 0 })
+        }
+
+        # @() matters on every one of these. A single-element array collapses to a bare object when
+        # it leaves an if statement, and Azure DevOps rejects the result as an empty collection.
+        return @{
+            name                = $Name
+            rank                = $Rank
+            owner               = @{ id = $script:AuthenticatedUserId }
+            variables           = $Variables
+            variableGroups      = @()
+            conditions          = @($conditions)
+            demands             = @()
+            schedules           = @()
+            environmentOptions  = @{
+                emailNotificationType   = 'OnlyOnFailure'
+                emailRecipients         = 'release.environment.owner;release.creator'
+                skipArtifactsDownload   = $false
+                timeoutInMinutes        = 0
+                enableAccessToken       = $false
+                publishDeploymentStatus = $true
+                badgeEnabled            = $false
+                autoLinkWorkItems       = $false
+            }
+            executionPolicy     = @{ concurrencyCount = 1; queueDepthCount = 0 }
+            retentionPolicy     = @{ daysToKeep = 30; releasesToKeep = 3; retainBuild = $true }
+            preDeployApprovals  = @{ approvals = @($preApprovals); approvalOptions = @{ releaseCreatorCanBeApprover = $true } }
+            postDeployApprovals = @{ approvals = @(@{ rank = 1; isAutomated = $true; isNotificationOn = $false; id = 0 }) }
+            preDeploymentGates  = $PreDeploymentGates
+            postDeploymentGates = @{ id = 0; gatesOptions = $null; gates = @() }
+            deployStep          = @{ id = 0 }
+            deployPhases        = @(@{
+                    rank            = 1
+                    phaseType       = 'agentBasedDeployment'
+                    name            = 'Agent job'
+                    refName         = $null
+                    workflowTasks   = @($Tasks | ForEach-Object { ConvertTo-WorkflowTask -Step $_ })
+                    deploymentInput = @{
+                        parallelExecution            = @{ parallelExecutionType = 'none' }
+                        agentSpecification           = $null
+                        skipArtifactsDownload        = $false
+                        artifactsDownloadInput       = @{}
+                        queueId                      = $script:QueueId
+                        demands                      = @()
+                        enableAccessToken            = $false
+                        timeoutInMinutes             = 0
+                        jobCancelTimeoutInMinutes    = 1
+                        condition                    = 'succeeded()'
+                        overrideInputs               = @{}
+                    }
+                })
+        }
+    }
+
+    $devTasks = @(
+        New-TaskStep -TaskName 'Bash' -DisplayName 'Multi-line deploy script' -Inputs @{ targetType = 'inline'; script = $script:MultiLineBash }
+        New-TaskStep -TaskName 'CmdLine' -DisplayName 'Disabled release step' -Enabled $false -Inputs @{ script = 'echo disabled in a release' }
+    )
+
+    $testTasks = @(if ($TaskGroups -and $TaskGroups.Leaf) {
+            New-TaskGroupStep -TaskGroupId $TaskGroups.Leaf.id -DisplayName 'Task group in a release' -Inputs @{
+                greeting       = 'released'
+                iterations     = '1'
+                unusedByCaller = 'never overridden'
+            }
+        }
+        else {
+            New-TaskStep -TaskName 'CmdLine' -DisplayName 'Test stage' -Inputs @{ script = 'echo test' }
+        })
+
+    $prodTasks = @(
+        New-TaskStep -TaskName 'PowerShell' -DisplayName 'Production script' -Inputs @{ targetType = 'inline'; script = $script:MultiLinePowerShell }
+    )
+
+    $environments = @(
+        New-Environment -Name 'Dev' -Rank 1 -Tasks $devTasks -ManualApproval $false -Variables @{
+            'fixture.stage' = @{ value = 'dev' }
+        }
+        New-Environment -Name 'Test' -Rank 2 -Tasks $testTasks -ManualApproval $true -AfterEnvironment 'Dev' -Variables @{
+            'fixture.stage' = @{ value = 'test' }
+        }
+        New-Environment -Name 'Prod' -Rank 3 -Tasks $prodTasks -ManualApproval $true -AfterEnvironment 'Test' -PreDeploymentGates $gates -Variables @{
+            'fixture.stage' = @{ value = 'prod' }
+        }
+    )
+
+    $triggers = @(@{ triggerType = 1; artifactAlias = $artifactAlias; triggerConditions = @() })
+
+    return Set-FixtureReleaseDefinition -Name "$($script:Prefix)release-multi-stage" `
+        -Environments $environments `
+        -Artifacts $artifacts `
+        -Triggers $triggers `
+        -VariableGroupIds @($VariableGroupId) `
+        -Variables @{ 'fixture.release.plain' = @{ value = 'release scoped value' } }
+}
+
+function Get-FixtureSharedQuery {
+    <#
+    .SYNOPSIS
+        Returns the first shared work item query, used by the optional release gate.
+    #>
+    [CmdletBinding()]
+    param()
+
+    try {
+        $folder = Invoke-AdoApi -Uri "$script:ProjectUri/_apis/wit/queries/Shared%20Queries?`$depth=1&api-version=$script:ApiVersion"
+        return $folder.children | Where-Object { -not $_.isFolder } | Select-Object -First 1
+    }
+    catch {
+        Write-Verbose "Shared query lookup failed: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+#endregion Fixtures
+
+#region Main
+
+if ($MyInvocation.InvocationName -ne '.') {
+    try {
+        $script:OrgUri = $OrganisationUri.TrimEnd('/')
+        $script:AuthorizationHeader = Get-AuthorizationHeader -Pat $Pat -EnvFile $EnvFile
+
+        $connection = Invoke-AdoApi -Uri "$script:OrgUri/_apis/connectionData?api-version=$script:PreviewApiVersion"
+        $script:AuthenticatedUserId = $connection.authenticatedUser.id
+        Write-Host "Connected to $script:OrgUri." -ForegroundColor Green
+
+        $projectObject = Get-FixtureProject -Name $Project
+
+        $script:ProjectId = $projectObject.id
+        $script:ProjectName = $projectObject.name
+        $script:ProjectUri = "$script:OrgUri/$([uri]::EscapeDataString($script:ProjectName))"
+        $script:VsrmProjectUri = "$(Get-VsrmUri -OrganisationUri $script:OrgUri)/$([uri]::EscapeDataString($script:ProjectName))"
+
+        $script:RepositoryReference = Get-FixtureRepositoryReference -TemplateDefinition $TemplateDefinition
+
+        $script:QueueId = (Get-HostedQueue).id
+        $script:Tasks = Get-InstalledTaskMap
+        Write-Verbose "Resolved $($script:Tasks.Count) installed tasks."
+
+        $variableGroup = Set-FixtureVariableGroup -Name $script:VariableGroupName
+        $variableGroupId = if ($variableGroup) { [int]$variableGroup.id } else { 0 }
+
+        $taskGroups = New-FixtureTaskGroups
+        $builds = New-FixtureBuildDefinitions -TaskGroups $taskGroups -VariableGroupId $variableGroupId
+
+        if ($builds.ContainsKey('Triggers') -and $builds.Triggers) {
+            New-FixtureReleaseDefinition -SourceBuildDefinition $builds.Triggers -TaskGroups $taskGroups -VariableGroupId $variableGroupId | Out-Null
+        }
+        else {
+            Write-Warning 'No source build definition, so the release fixture was skipped.'
+        }
+
+        Write-Host "Fixtures prefixed '$script:Prefix' are up to date in project '$script:ProjectName'." -ForegroundColor Green
+        Write-Host "Convert them with: yamlizr --filter $script:Prefix" -ForegroundColor Green
+        exit 0
+    }
+    catch {
+        Write-Error -ErrorAction Continue "Fixture setup failed: $($_.Exception.Message)"
+        exit 1
+    }
+}
+
+#endregion Main

--- a/.scripts/README.md
+++ b/.scripts/README.md
@@ -1,0 +1,109 @@
+# Repository Scripts
+
+Tooling that supports development of yamlizr but ships with none of it.
+
+## New-FixtureDefinitions.ps1
+
+Creates or updates the Azure DevOps conversion fixtures that [issue #366](https://github.com/f2calv/yamlizr/issues/366) calls for: a set of deliberately awkward classic Build and Release definitions, so the integration tests can prove yamlizr converts a real definition correctly rather than only converting a hand-built one.
+
+The script is the reproducible record of how those definitions were built. It never deletes; every operation is an upsert keyed on the object name, so it is safe to re-run.
+
+### Sharing a project, and the name prefix
+
+The script adds definitions to an existing project and never creates one. The fixture organisation is a GitHub-provisioned account whose single project already holds unrelated pipelines, so the fixtures have to coexist with them.
+
+Every object the script creates therefore carries a common prefix, `yamlizr.test.` by default. That keeps the fixtures identifiable, guarantees the script never touches anything outside the prefix, and means the conversion is driven with yamlizr's own filter:
+
+```powershell
+yamlizr --filter yamlizr.test.
+```
+
+which exercises `--filter` rather than leaving it untested.
+
+### Why a script rather than the MCP server
+
+The [Azure DevOps MCP server](https://github.com/microsoft/azure-devops-mcp) is configured in [.vscode/mcp.json](../.vscode/mcp.json) and is useful for inspecting the fixtures, but it cannot build them. Its only pipeline write tool, `pipelines_write.create_pipeline`, creates YAML pipelines. The fixtures need classic designer definitions, task groups, variable groups and release definitions, none of which the MCP server exposes. The script calls the REST API directly instead.
+
+### Credentials
+
+Two tokens are in play and they are deliberately different.
+
+| Token | Scope | Used by | Stored in |
+| --- | --- | --- | --- |
+| Full access | Read and write | This script and the MCP server | `.env` as `AZURE_DEVOPS_PAT` |
+| Read only | Build, Release, Task Groups and Variable Groups read | The integration tests | User Secrets as `CasCap:AzureDevOpsOptions:PAT` |
+
+Copy [.env.example](../.env.example) to `.env` and set `AZURE_DEVOPS_PAT` to the raw token exactly as Azure DevOps issued it. No encoding, no quotes. `.env` is git-ignored and must never be committed.
+
+The MCP server itself reads a variable named `PERSONAL_ACCESS_TOKEN` whose contents are not a personal access token but base64 of `<email>:<pat>`. Rather than push that onto whoever populates `.env`, [Start-AdoMcpServer.ps1](Start-AdoMcpServer.ps1) derives it. Restart the `ado` server from the MCP view after changing `.env`; it is read only at start-up.
+
+Pass `-Pat` instead if you would rather not keep a token on disk:
+
+```powershell
+$token = Read-Host 'PAT' -MaskInput
+./.scripts/New-FixtureDefinitions.ps1 -OrganisationUri https://dev.azure.com/contoso -Project demo -Pat $token
+```
+
+Required scopes for the full-access token: Project and Team (read), Build (read and execute), Release (read, write, execute and manage), Task Groups (read, create and manage), Variable Groups (read, create and manage).
+
+`Code` is deliberately not required. A classic Build definition must name a repository, and the binding for a GitHub repository carries a service connection id plus a page of provider metadata that cannot be reconstructed from a repository name. The script copies that binding from an existing definition rather than enumerating Azure Repos, which would need `Code` and would fail in an organisation that has no Azure Repos repository. Nothing is ever pushed to the borrowed repository, and no fixture definition is ever queued.
+
+### Usage
+
+Review what would change before writing anything:
+
+```powershell
+./.scripts/New-FixtureDefinitions.ps1 -OrganisationUri https://dev.azure.com/contoso -Project demo -WhatIf
+```
+
+Then apply it:
+
+```powershell
+./.scripts/New-FixtureDefinitions.ps1 -OrganisationUri https://dev.azure.com/contoso -Project demo
+```
+
+`-WhatIf` cannot report the whole set. Objects that depend on one the script would have created — the nested task group, the task group definition and the release definition — are skipped, because their dependency does not exist in a dry run.
+
+| Parameter | Default | Purpose |
+| --- | --- | --- |
+| `-OrganisationUri` | required | Absolute organisation Uri, for example `https://dev.azure.com/contoso` |
+| `-Project` | required | Existing project to add the fixtures to. Never created |
+| `-Prefix` | `yamlizr.test.` | Applied to every object created, and the value to pass to `yamlizr --filter` |
+| `-TemplateDefinition` | first definition | Existing definition whose repository binding the fixtures copy |
+| `-Pat` | from `.env` | Full-access token as a `SecureString` |
+| `-EnvFile` | `../.env` | Location of the file holding `AZURE_DEVOPS_PAT` |
+| `-IncludeGates` | off | Adds a pre-deployment gate, which needs a shared work item query |
+| `-IncludeUnknownTask` | off | Adds a step referencing an uninstalled task, which Azure DevOps may reject |
+
+### What the fixture contains
+
+Names below assume the default prefix.
+
+| Object | Covers |
+| --- | --- |
+| `yamlizr.test.multi-phase` | Three agent phases, phase-to-phase dependencies, a fan-in, and a phase condition other than `succeeded()` |
+| `yamlizr.test.server-phase` | An agentless phase next to an agent phase, so the phase yamlizr skips is exercised |
+| `yamlizr.test.multiline-scripts` | Multi-line Bash, PowerShell and cmd scripts, a trailing blank line, and a whitespace-only script |
+| `yamlizr.test.task-groups` | A task group whose name contains spaces, referenced four times: defaults kept, defaults overridden, nested, and disabled |
+| `yamlizr.test.triggers-and-variables` | Continuous integration, pull request and scheduled triggers with branch and path filters, definition variables including a secret and one settable at queue time, and a linked variable group |
+| `yamlizr.test.uninstalled-extension` | A step whose task is not installed, covering the null path in [issue #177](https://github.com/f2calv/yamlizr/issues/177). Only created with `-IncludeUnknownTask` |
+| `yamlizr.test.Task Group With Spaces` | Parameters with default values, a multi-line script, and a disabled step |
+| `yamlizr.test.Nested Task Group` | Calls the task group above, covering recursive expansion |
+| `yamlizr.test.common` | A variable group carrying plain, spaced and secret values |
+| `yamlizr.test.release-multi-stage` | Three environments, a build artifact, automated and manual pre-deployment approvals, stage-after-stage conditions, a continuous deployment trigger, stage-scoped variables, a disabled step and an optional gate |
+
+No value in the fixture is a real credential, and no definition is ever queued.
+
+## Start-AdoMcpServer.ps1
+
+Launches the Azure DevOps MCP server for the `ado` entry in [.vscode/mcp.json](../.vscode/mcp.json). Not run by hand.
+
+It exists so `.env` can hold the raw token under a name that means what it says. The server's own contract is a variable called `PERSONAL_ACCESS_TOKEN` holding base64 of `<email>:<pat>` — a name that promises a token and contents that are not one. Getting it wrong fails as a 401 that reads like a missing scope. The launcher reads `AZURE_DEVOPS_PAT`, derives what the server wants, and writes nothing to stdout, which carries the MCP JSON-RPC session.
+
+It also removes a start-up ordering trap: VS Code's `envFile` fails the whole connection when `.env` is absent, whereas the launcher reports a readable message on stderr.
+
+## Validating the generated YAML
+
+Install the recommended workspace extensions from [.vscode/extensions.json](../.vscode/extensions.json). The [Azure Pipelines extension](https://marketplace.visualstudio.com/items?itemName=ms-azure-devops.azure-pipelines) validates converted YAML against the Azure Pipelines schema, so a file yamlizr emits can be opened and checked without pushing it anywhere.
+
+By default that extension only applies to files matching `azure-pipelines.yml`. Point it at the converted output by adding a `yaml.schemas` association in your workspace settings, or by naming the generated files to match.

--- a/.scripts/README.md
+++ b/.scripts/README.md
@@ -91,6 +91,7 @@ Names below assume the default prefix.
 | `yamlizr.test.Nested Task Group` | Calls the task group above, covering recursive expansion |
 | `yamlizr.test.common` | A variable group carrying plain, spaced and secret values |
 | `yamlizr.test.release-multi-stage` | Three environments, a build artifact, automated and manual pre-deployment approvals, stage-after-stage conditions, a continuous deployment trigger, stage-scoped variables, a disabled step and an optional gate |
+| `yamlizr.test.validation` | An empty YAML pipeline used only as a target for validating generated YAML. Deliberately the one fixture left enabled |
 
 No value in the fixture is a real credential, and no definition is ever queued.
 
@@ -104,6 +105,22 @@ It also removes a start-up ordering trap: VS Code's `envFile` fails the whole co
 
 ## Validating the generated YAML
 
-Install the recommended workspace extensions from [.vscode/extensions.json](../.vscode/extensions.json). The [Azure Pipelines extension](https://marketplace.visualstudio.com/items?itemName=ms-azure-devops.azure-pipelines) validates converted YAML against the Azure Pipelines schema, so a file yamlizr emits can be opened and checked without pushing it anywhere.
+There are two routes, and they disagree in useful ways.
 
-By default that extension only applies to files matching `azure-pipelines.yml`. Point it at the converted output by adding a `yaml.schemas` association in your workspace settings, or by naming the generated files to match.
+### Against Azure DevOps
+
+The pipeline preview endpoint parses a document and expands its templates without queueing anything, which is the only check that proves Azure DevOps will actually accept the output. `IApiService.Validate` wraps it, and `PipelineValidationTests` exercises it.
+
+It needs an existing YAML pipeline to parse against, which is what `yamlizr.test.validation` is for. That pipeline must be **enabled**; a disabled one fails the call with `DefinitionDisabledException` rather than validating anything. Point the tests at it:
+
+```powershell
+dotnet user-secrets set CasCap:AzureDevOpsOptions:ValidationPipelineId 19 --project src/CasCap.Api.AzureDevOps.Tests
+```
+
+One limitation: a relative `template:` reference resolves against the target pipeline's repository, not the submitted document. Generated YAML that references a task group template therefore only validates when those templates are committed, or when it was generated with `--inline`.
+
+### In the editor
+
+Install the recommended workspace extensions from [.vscode/extensions.json](../.vscode/extensions.json). The [Azure Pipelines extension](https://marketplace.visualstudio.com/items?itemName=ms-azure-devops.azure-pipelines) checks converted YAML against the published schema, and [.vscode/settings.json](../.vscode/settings.json) associates the folders yamlizr writes with it. Note that the extension only diagnoses **open** documents, so a closed file reporting no problems has not been checked.
+
+The editor schema is stricter than the server in places: it rejects `variables: []`, which a preview run accepts.

--- a/.scripts/Start-AdoMcpServer.ps1
+++ b/.scripts/Start-AdoMcpServer.ps1
@@ -1,0 +1,90 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+    Launches the Azure DevOps MCP server with a credential read from .env.
+
+.DESCRIPTION
+    The server's PAT mode reads an environment variable called PERSONAL_ACCESS_TOKEN, and expects it
+    to hold the base64 encoding of "<email>:<pat>" rather than the token itself. The name says token
+    and the contents are not a token, which is easy to get wrong by hand and fails as a 401 that
+    reads like a permissions problem.
+
+    So .env carries AZURE_DEVOPS_PAT, the raw token under a name that means what it says, and this
+    launcher derives what the server actually wants.
+
+    Nothing is written to stdout. That stream carries the MCP JSON-RPC session, and any stray output
+    corrupts it, so diagnostics go to stderr.
+
+.PARAMETER Organisation
+    Azure DevOps organisation name, the segment after dev.azure.com/.
+
+.PARAMETER EnvFile
+    Path to the .env file holding AZURE_DEVOPS_PAT. Defaults to .env in the repository root.
+
+.PARAMETER Domain
+    Tool domains to load. Fewer domains means a shorter tool list for the agent to choose from.
+
+.EXAMPLE
+    ./.scripts/Start-AdoMcpServer.ps1 -Organisation contoso
+
+.NOTES
+    Invoked by the `ado` server in .vscode/mcp.json rather than run by hand.
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Organisation,
+
+    [Parameter()]
+    [string]$EnvFile = (Join-Path $PSScriptRoot '..' '.env'),
+
+    [Parameter()]
+    [string[]]$Domain = @('core', 'pipelines', 'repositories')
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+# npx reports its own failures; letting PowerShell also throw on a non-zero exit adds noise.
+$PSNativeCommandUseErrorActionPreference = $false
+
+function Write-Diagnostic {
+    param([string]$Message)
+    [Console]::Error.WriteLine($Message)
+}
+
+$token = $env:AZURE_DEVOPS_PAT
+
+if ([string]::IsNullOrWhiteSpace($token) -and (Test-Path -LiteralPath $EnvFile)) {
+    foreach ($line in Get-Content -LiteralPath $EnvFile) {
+        if ($line -match '^\s*AZURE_DEVOPS_PAT\s*=\s*(.+?)\s*$') {
+            $token = $Matches[1].Trim("'", '"')
+            break
+        }
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($token)) {
+    Write-Diagnostic "yamlizr: no credential found."
+    Write-Diagnostic "yamlizr: set AZURE_DEVOPS_PAT=<raw token> in '$([IO.Path]::GetFullPath($EnvFile))', then restart this server."
+    Write-Diagnostic 'yamlizr: see .env.example. The variable was renamed from PERSONAL_ACCESS_TOKEN and now holds the raw token, not base64.'
+    exit 1
+}
+
+# The server wants base64 of "<email>:<pat>". The email half is never validated.
+$env:PERSONAL_ACCESS_TOKEN = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes("yamlizr:$token"))
+
+# -CommandType Application skips npx.ps1, which PowerShell would otherwise prefer and run in-process.
+$npx = Get-Command 'npx' -CommandType Application -ErrorAction SilentlyContinue | Select-Object -First 1
+if (-not $npx) {
+    Write-Diagnostic 'yamlizr: npx was not found on PATH. Install Node.js 20 or later.'
+    exit 1
+}
+
+$arguments = @('-y', '@azure-devops/mcp', $Organisation, '--authentication', 'pat')
+if ($Domain) { $arguments += @('-d') + $Domain }
+
+& $npx.Source @arguments
+exit $LASTEXITCODE

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "ms-azure-devops.azure-pipelines",
+    "redhat.vscode-yaml",
+    "ms-dotnettools.csdevkit",
+    "editorconfig.editorconfig"
+  ]
+}

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,23 @@
+{
+  "inputs": [
+    {
+      "id": "ado_org",
+      "type": "promptString",
+      "description": "Azure DevOps organisation name (the segment after dev.azure.com/)"
+    }
+  ],
+  "servers": {
+    "ado": {
+      "type": "stdio",
+      "command": "pwsh",
+      "args": [
+        "-NoProfile",
+        "-NonInteractive",
+        "-File",
+        "${workspaceFolder}/.scripts/Start-AdoMcpServer.ps1",
+        "-Organisation",
+        "${input:ado_org}"
+      ]
+    }
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  // yamlizr writes converted definitions into these folders under <outputpath>/<project>.
+  // Associating them with the azure-pipelines language makes the Azure Pipelines extension
+  // schema-validate the generated YAML in place, without pushing it to an organisation.
+  "files.associations": {
+    "**/AzureDevOpsBuilds/*.yml": "azure-pipelines",
+    "**/AzureDevOpsReleases/*.yml": "azure-pipelines",
+    "**/AzureDevOpsTaskGroups/*.yml": "azure-pipelines"
+  },
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-workflow.json": [
+      "**/GitHubBuilds/*.yml",
+      "**/GitHubReleases/*.yml"
+    ]
+  }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
     <PackageVersion Include="CasCap.Common.Extensions" Version="4.12.7" />
     <PackageVersion Include="CasCap.Common.Net" Version="4.12.7" />
     <PackageVersion Include="CasCap.Common.Testing" Version="4.12.7" />
-    <PackageVersion Include="Figgle" Version="0.6.6" />
     <PackageVersion Include="Figgle.Fonts" Version="0.6.6" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="5.1.0" />
     <PackageVersion Include="McMaster.Extensions.Hosting.CommandLine" Version="5.1.0" />
@@ -16,7 +15,6 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="20.256.2" />
     <PackageVersion Include="Microsoft.TeamFoundationServer.Client" Version="20.256.2" />
     <PackageVersion Include="Microsoft.VisualStudio.Services.Client" Version="20.256.2" />

--- a/Dockerfile.Debug
+++ b/Dockerfile.Debug
@@ -1,0 +1,100 @@
+# syntax=docker/dockerfile:1-labs
+# check=skip=CopyIgnoredFile
+#
+# Debug variant of Dockerfile, used to verify a fix against the local sibling repositories before
+# they are published as packages.
+#
+# In Debug, src/CasCap.Api.AzureDevOps/CasCap.Api.AzureDevOps.csproj swaps its CasCap.Common.*
+# PackageReferences for ProjectReferences at ..\..\..\CasCap.Common\. From /repo/src/<project>/ that
+# resolves to /CasCap.Common, so the sibling repository has to sit at the filesystem root inside the
+# image. build.ps1 and build.sh mirror it into deps/ first, because a build context cannot reach
+# outside the repository.
+#
+# Not published. The image job in .github/workflows/ci.yml always builds Dockerfile.
+#
+# ------------------------------------------------------------------------------
+# Stage 1 of 2: build
+# ------------------------------------------------------------------------------
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /repo
+
+ARG PROJECT=src/CasCap.DevOpsYamlizrCli/CasCap.DevOpsYamlizrCli.csproj
+ARG CONFIGURATION=Debug
+ARG TARGET_FRAMEWORK=net10.0
+ARG VERSION=0.0.1
+
+# -- Dependency layer ----------------------------------------------------------
+# Only the manifests restore reads, so editing a .cs file in either repository reuses the cache.
+COPY Directory.Build.props Directory.Packages.props ./
+
+# The /./ pivot drops the deps/ prefix, so deps/CasCap.Common/... lands at /CasCap.Common/...
+COPY --parents deps/./**/*.csproj deps/./**/*.props deps/./**/*.targets /
+COPY --parents src/**/*.csproj ./
+
+RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked \
+    dotnet restore "$PROJECT" -p:Configuration="$CONFIGURATION"
+
+# -- Compile layer -------------------------------------------------------------
+COPY deps/CasCap.Common /CasCap.Common
+COPY . .
+
+ARG TARGETARCH
+ARG TARGETVARIANT
+RUN --mount=type=cache,target=/root/.nuget/packages,sharing=locked <<EOF
+set -eux
+# https://learn.microsoft.com/dotnet/core/rid-catalog
+case "${TARGETARCH}${TARGETVARIANT}" in
+    amd64) RID=linux-x64   ;;
+    arm64) RID=linux-arm64 ;;
+    armv7) RID=linux-arm   ;;
+    *) echo "unsupported platform: linux/${TARGETARCH}/${TARGETVARIANT}" >&2; exit 1 ;;
+esac
+dotnet publish "$PROJECT" \
+    --configuration "$CONFIGURATION" \
+    --framework "$TARGET_FRAMEWORK" \
+    --runtime "$RID" \
+    --self-contained false \
+    -p:Version="$VERSION" \
+    --output /out
+EOF
+
+# ------------------------------------------------------------------------------
+# Stage 2 of 2: final
+#
+# aspnet, not runtime, for the same reason as the Release image: a FrameworkReference to
+# Microsoft.AspNetCore.App arrives through CasCap.Common.Net.
+# ------------------------------------------------------------------------------
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled AS final
+WORKDIR /app
+COPY --from=build /out .
+
+# Generated YAML is written here; mount a host directory over it.
+VOLUME /data
+
+# -- Provenance ----------------------------------------------------------------
+ARG GIT_REPOSITORY=n/a
+ENV GIT_REPOSITORY=$GIT_REPOSITORY
+ARG GIT_BRANCH=n/a
+ENV GIT_BRANCH=$GIT_BRANCH
+ARG GIT_COMMIT=n/a
+ENV GIT_COMMIT=$GIT_COMMIT
+ARG GIT_TAG=n/a
+ENV GIT_TAG=$GIT_TAG
+
+ARG GITHUB_WORKFLOW=n/a
+ENV GITHUB_WORKFLOW=$GITHUB_WORKFLOW
+ARG GITHUB_RUN_ID=0
+ENV GITHUB_RUN_ID=$GITHUB_RUN_ID
+ARG GITHUB_RUN_NUMBER=0
+ENV GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER
+
+LABEL org.opencontainers.image.title="yamlizr (debug)" \
+    org.opencontainers.image.description="Local debug build against sibling CasCap.Common sources" \
+    org.opencontainers.image.source="https://github.com/f2calv/yamlizr" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.version="$GIT_TAG" \
+    org.opencontainers.image.revision="$GIT_COMMIT"
+
+USER $APP_UID
+
+ENTRYPOINT ["dotnet", "yamlizr.dll"]

--- a/README.md
+++ b/README.md
@@ -245,6 +245,33 @@ explicitly;
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 ```
 
+The container needs no .NET on the agent. Nothing from the agent reaches it unless you forward it, so
+the predefined variables above are not available inside the container and the organisation and project
+have to be passed as arguments;
+
+```yaml
+- script: |
+    docker run --pull always --rm \
+      --user "`id -u`:`id -g`" \
+      -e CasCap__AzureDevOpsOptions__PAT \
+      -v "$(Build.ArtifactStagingDirectory):/data" \
+      ghcr.io/f2calv/yamlizr generate \
+        -org $(System.CollectionUri) \
+        -proj $(System.TeamProject) \
+        -out /data \
+        --create-directory
+  displayName: yamlizr
+  env:
+    CasCap__AzureDevOpsOptions__PAT: $(System.AccessToken)
+```
+
+Two details worth keeping;
+
+- `-e NAME` with no value forwards the variable from the step environment, keeping the token out of the
+  command line and out of `docker inspect`.
+- The user mapping uses backticks because Azure Pipelines resolves its own `$( )` macros before bash
+  sees the script. Without it the generated files belong to uid 1654 and the agent cannot clean them up.
+
 ## How It Works
 
 > This tool was created when there was no means of exporting a designer/classic build/release definition to YAML. As of November 2020 there is a new [Export to YAML](https://devblogs.microsoft.com/devops/replacing-view-yaml/) feature which allows you to export a _Build_ pipeline to YAML with a single click. This official function covers more edge cases than this CLI for Build pipelines. Where this CLI still has benefits is that it also converts Release definitions to YAML, which the official tool does not. It also allows the conversion of every single Build/Release definition en-masse, so much less clicking! Then you can then cut/copy/paste/manipulate the generated YAML steps as required to fit into a build and/or deployment pipeline unique to your own requirements.

--- a/README.md
+++ b/README.md
@@ -192,8 +192,7 @@ Sources are read in the following order, each overriding the last;
 2. `appsettings.json` in the current working directory
 3. .NET User Secrets
 4. environment variables
-5. the predefined Azure Pipelines variables `SYSTEM_ACCESSTOKEN`, `SYSTEM_COLLECTIONURI` and
-   `SYSTEM_TEAMPROJECT`
+5. the predefined Azure Pipelines variables, see [Running Inside a Pipeline](#running-inside-a-pipeline)
 
 ```json
 {
@@ -232,8 +231,10 @@ read scopes listed above and pass `$(System.AccessToken)`;
   displayName: yamlizr
 ```
 
-Alternatively supply nothing and let yamlizr fall back to the predefined pipeline variables. Azure
-Pipelines only exposes `SYSTEM_ACCESSTOKEN` to a step when you map it explicitly;
+Alternatively supply nothing and let yamlizr fall back to the predefined pipeline variables
+`SYSTEM_ACCESSTOKEN`, `SYSTEM_COLLECTIONURI` and `SYSTEM_TEAMPROJECT`. The latter two are exposed to
+every step automatically, but `SYSTEM_ACCESSTOKEN` is secret and reaches a step only when you map it
+explicitly;
 
 ```yaml
 - script: |

--- a/README.md
+++ b/README.md
@@ -288,10 +288,6 @@ without a trace. Progress on closing these gaps is tracked in
 - [CommandLineUtils](https://github.com/natemcmaster/CommandLineUtils)
 - [ShellProgressBar](https://github.com/Mpdreamz/shellprogressbar)
 
-## Misc Tips
-
-- The [NuGet package](https://www.nuget.org/packages/yamlizr/) includes [SourceLink](https://github.com/dotnet/sourcelink) which enables you to jump inside the library and debug the API yourself. By default Visual Studio does not allow this and will pop up an message "You are debugging a Release build of...", to disable this message go into the Visual Studio debugging options and un-check the 'Just My Code' option (menu path, Tools > Options > Debugging).
-
 ## Feedback/Issues
 
 Please post any issues or feedback [to GitHub issues](https://github.com/f2calv/yamlizr/issues).

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,356 @@
+#!/usr/bin/env pwsh
+#Requires -Version 7.4
+<#
+.SYNOPSIS
+    Builds the yamlizr container image locally, and optionally publishes it to ghcr.io.
+
+.DESCRIPTION
+    Mirrors the image job in .github/workflows/ci.yml, so a Dockerfile change can be verified before
+    it reaches CI.
+
+    A local build targets one platform and uses --load, so the image lands in the local engine and
+    can actually be run. That matters here: 3.1.6 shipped an image that built cleanly and then
+    exited with "No frameworks were found", so the build finishes by running the image unless
+    -SkipSmokeTest is passed.
+
+    A push build targets every published platform. A multi-architecture manifest cannot be loaded
+    into the local engine, so --push replaces --load and the smoke test is skipped.
+
+.PARAMETER Push
+    Authenticate to ghcr.io through the gh CLI and publish the image instead of building locally.
+
+.PARAMETER Configuration
+    Release builds Dockerfile. Debug builds Dockerfile.Debug, which compiles against the local
+    sibling CasCap.Common repository, mirrored into deps/ first because a build context cannot reach
+    outside the repository.
+
+.PARAMETER Tag
+    Image tag override. Defaults to the GitVersion semantic version when -Push, otherwise
+    "latest-dev".
+
+.PARAMETER Version
+    Version compiled into the assembly. Must be a valid semantic version, so it is resolved
+    separately from the image tag, which may be a moving label such as "latest-dev".
+
+.PARAMETER Platforms
+    Target platform list. Defaults to every published platform when -Push, otherwise the host
+    architecture alone, because --load accepts a single platform and a cross-built image is slow.
+
+.PARAMETER ImageName
+    Image repository name under the registry.
+
+.PARAMETER SkipSmokeTest
+    Skip running the built image. The smoke test is skipped automatically for a push build.
+
+.EXAMPLE
+    ./build.ps1
+
+    Builds for the host architecture, loads the image, then runs it to prove it starts.
+
+.EXAMPLE
+    ./build.ps1 -Platforms linux/amd64,linux/arm64,linux/arm/v7 -SkipSmokeTest
+
+    Cross-builds every published platform without loading or running anything.
+
+.EXAMPLE
+    ./build.ps1 -Push
+
+.NOTES
+    Requires Docker with buildx. Pushing also requires the gh CLI, and tag resolution uses
+    GitVersion.Tool, which is installed on demand.
+#>
+[CmdletBinding(SupportsShouldProcess)]
+param(
+    [switch]$Push,
+
+    [ValidateSet('Debug', 'Release')]
+    [string]$Configuration = 'Release',
+
+    [string]$Tag,
+
+    [string]$Version,
+
+    [string]$Platforms,
+
+    [ValidateNotNullOrEmpty()]
+    [string]$ImageName = 'yamlizr',
+
+    [switch]$SkipSmokeTest
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version 3.0
+
+# docker and gh report their own failures; letting PowerShell also throw doubles the noise.
+$PSNativeCommandUseErrorActionPreference = $false
+
+$REGISTRY = 'ghcr.io/f2calv'
+$REPO_ROOT = [IO.Path]::GetFullPath($PSScriptRoot)
+$BUILDER_NAME = 'yamlizr1'
+$ALL_PLATFORMS = 'linux/amd64,linux/arm64,linux/arm/v7'
+
+# Mirrored into deps/ for a Debug build, so a fix can be verified before those repos are published.
+$DEP_REPOS = @('CasCap.Common')
+
+$GIT_REPOSITORY = $REPO_ROOT | Split-Path -Leaf
+$GIT_BRANCH = "$(git -C $REPO_ROOT branch --show-current)".Trim()
+$GIT_COMMIT = "$(git -C $REPO_ROOT rev-parse HEAD)".Trim()
+
+$GITHUB_WORKFLOW = 'local'
+$GITHUB_RUN_ID = 0
+$GITHUB_RUN_NUMBER = 0
+
+#region Resolution
+
+function Install-GitVersion {
+    <#
+    .SYNOPSIS
+        Ensures dotnet-gitversion is on PATH, installing it when it is missing.
+    #>
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param()
+
+    if (Get-Command dotnet-gitversion -ErrorAction SilentlyContinue) { return $true }
+
+    Write-Host 'dotnet-gitversion not found, installing GitVersion.Tool globally.' -ForegroundColor Cyan
+    dotnet tool install -g GitVersion.Tool
+    if ($LASTEXITCODE -ne 0) { return $false }
+
+    $toolsPath = Join-Path $HOME '.dotnet/tools'
+    if ($env:PATH -notlike "*$toolsPath*") {
+        $env:PATH = "$toolsPath$([IO.Path]::PathSeparator)$env:PATH"
+    }
+
+    return [bool](Get-Command dotnet-gitversion -ErrorAction SilentlyContinue)
+}
+
+function Resolve-Version {
+    <#
+    .SYNOPSIS
+        Returns the semantic version compiled into the assembly.
+    .DESCRIPTION
+        Kept separate from the image tag. The Dockerfile feeds this to dotnet publish as
+        -p:Version, which rejects a moving label such as "latest-dev".
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param([bool]$Required)
+
+    if ($Version) { return $Version }
+
+    if (Install-GitVersion) {
+        $resolved = "$(dotnet-gitversion $REPO_ROOT /showvariable SemVer)".Trim()
+        if (-not [string]::IsNullOrWhiteSpace($resolved)) { return $resolved }
+    }
+
+    if ($Required) {
+        throw 'Could not resolve a version from GitVersion, which a push build requires. Pass -Version.'
+    }
+
+    # Matches the Dockerfile default, so a local build without GitVersion still succeeds.
+    Write-Warning 'Could not resolve a version from GitVersion, falling back to 0.0.1.'
+    return '0.0.1'
+}
+
+function Resolve-Platforms {
+    <#
+    .SYNOPSIS
+        Returns the platform list to build for.
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param()
+
+    if ($Platforms) { return $Platforms }
+    if ($Push) { return $ALL_PLATFORMS }
+
+    # --load accepts one platform only, and emulating another is far slower.
+    switch ([Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()) {
+        'Arm64' { return 'linux/arm64' }
+        'Arm' { return 'linux/arm/v7' }
+        default { return 'linux/amd64' }
+    }
+}
+
+function Connect-Ghcr {
+    <#
+    .SYNOPSIS
+        Authenticates the local Docker client to ghcr.io using the gh CLI token.
+    #>
+    [CmdletBinding()]
+    param()
+
+    if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+        throw 'gh CLI not found. Install it from https://cli.github.com'
+    }
+
+    if (-not (gh auth status 2>&1 | Select-String -SimpleMatch 'write:packages')) {
+        Write-Host 'Refreshing gh auth to add the write:packages scope.' -ForegroundColor Cyan
+        gh auth refresh -h github.com -s write:packages
+        if ($LASTEXITCODE -ne 0) { throw 'gh auth refresh failed.' }
+    }
+
+    $ghUser = "$(gh api user --jq .login)".Trim()
+    Write-Host "Authenticating Docker to ghcr.io as $ghUser." -ForegroundColor Cyan
+
+    gh auth token | docker login ghcr.io -u $ghUser --password-stdin
+    if ($LASTEXITCODE -ne 0) { throw 'docker login ghcr.io failed.' }
+}
+
+#endregion Resolution
+
+#region Build
+
+function Initialize-Builder {
+    <#
+    .SYNOPSIS
+        Selects the buildx builder, creating it on first use.
+    #>
+    [CmdletBinding()]
+    param()
+
+    docker buildx inspect $BUILDER_NAME *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "Creating buildx builder '$BUILDER_NAME'." -ForegroundColor Cyan
+        docker buildx create --name $BUILDER_NAME | Out-Null
+        if ($LASTEXITCODE -ne 0) { throw "docker buildx create failed for '$BUILDER_NAME'." }
+    }
+
+    docker buildx use $BUILDER_NAME
+    if ($LASTEXITCODE -ne 0) { throw "docker buildx use failed for '$BUILDER_NAME'." }
+}
+
+function Invoke-SmokeTest {
+    <#
+    .SYNOPSIS
+        Runs the built image, because a successful build does not prove the image starts.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Image,
+        [Parameter(Mandatory)][string]$ExpectedVersion
+    )
+
+    Write-Host 'Running the image to prove it starts.' -ForegroundColor Cyan
+
+    $reported = "$(docker run --rm $Image --version)".Trim()
+    if ($LASTEXITCODE -ne 0) { throw 'docker run --version failed, so the image does not start.' }
+
+    # SourceLink may append +<sha> to the informational version, so match the prefix.
+    if (-not $reported.StartsWith($ExpectedVersion)) {
+        throw "Expected a version starting with '$ExpectedVersion', got '$reported'."
+    }
+    Write-Host "  reported version: $reported" -ForegroundColor DarkGray
+
+    docker run --rm $Image generate --help | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'docker run generate --help failed.' }
+    Write-Host '  generate --help: ok' -ForegroundColor DarkGray
+}
+
+function Sync-Deps {
+    <#
+    .SYNOPSIS
+        Mirrors the sibling repositories a Debug build compiles against into deps/.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+
+    $parent = Split-Path $REPO_ROOT -Parent
+
+    foreach ($repo in $DEP_REPOS) {
+        $source = Join-Path $parent $repo
+        if (-not (Test-Path -LiteralPath $source)) {
+            throw "A Debug build needs the sibling repository '$repo' at '$source', which was not found. Use -Configuration Release instead."
+        }
+
+        $destination = Join-Path (Join-Path $REPO_ROOT 'deps') $repo
+        if (-not $PSCmdlet.ShouldProcess($repo, 'Mirror sibling repository into deps/')) { continue }
+
+        Write-Host "Syncing $repo -> deps/$repo" -ForegroundColor Cyan
+        robocopy $source $destination /MIR `
+            /XD bin obj .git .vs node_modules deps `
+            /XF 'appsettings.Local*.json' '*.user' `
+            /NFL /NDL /NJH /NJS /NP | Out-Null
+
+        # robocopy uses exit codes below 8 to report work done, not failure.
+        if ($LASTEXITCODE -ge 8) { throw "robocopy failed for $repo with exit code $LASTEXITCODE." }
+    }
+
+    $global:LASTEXITCODE = 0
+}
+
+function Invoke-Build {
+    <#
+    .SYNOPSIS
+        Builds, and optionally publishes, the container image.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param()
+
+    $versionValue = Resolve-Version -Required:$Push
+    $tagValue = if ($Tag) { $Tag.ToLower() } elseif ($Push) { $versionValue.ToLower() } else { 'latest-dev' }
+    $platformValue = Resolve-Platforms
+    $image = "$REGISTRY/$($ImageName.ToLower()):$tagValue"
+    $dockerfile = if ($Configuration -eq 'Debug') { 'Dockerfile.Debug' } else { 'Dockerfile' }
+
+    if ($Push -and $Configuration -eq 'Debug') {
+        throw 'A Debug image is built against unpublished local sources and must not be pushed.'
+    }
+
+    if ($Push -and -not $PSCmdlet.ShouldProcess($image, 'Publish container image to ghcr.io')) { return }
+
+    Write-Host "Image     : $image" -ForegroundColor Cyan
+    Write-Host "Version   : $versionValue" -ForegroundColor Cyan
+    Write-Host "Platforms : $platformValue" -ForegroundColor Cyan
+    Write-Host "Dockerfile: $dockerfile" -ForegroundColor Cyan
+
+    if ($Configuration -eq 'Debug') { Sync-Deps }
+    if ($Push) { Connect-Ghcr }
+    Initialize-Builder
+
+    # A multi-architecture manifest cannot be loaded into the local engine.
+    $outputArg = if ($Push) { '--push' } elseif ($platformValue.Contains(',')) { '--pull' } else { '--load' }
+
+    docker buildx build `
+        --tag $image `
+        --file (Join-Path $REPO_ROOT $dockerfile) `
+        --build-arg VERSION=$versionValue `
+        --build-arg CONFIGURATION=$Configuration `
+        --build-arg GIT_REPOSITORY=$GIT_REPOSITORY `
+        --build-arg GIT_BRANCH=$GIT_BRANCH `
+        --build-arg GIT_COMMIT=$GIT_COMMIT `
+        --build-arg GIT_TAG=$tagValue `
+        --build-arg GITHUB_WORKFLOW=$GITHUB_WORKFLOW `
+        --build-arg GITHUB_RUN_ID=$GITHUB_RUN_ID `
+        --build-arg GITHUB_RUN_NUMBER=$GITHUB_RUN_NUMBER `
+        --platform $platformValue `
+        $outputArg `
+        $REPO_ROOT
+
+    if ($LASTEXITCODE -ne 0) { throw "docker buildx build failed with exit code $LASTEXITCODE." }
+
+    if ($Push) {
+        Write-Host "Pushed: $image" -ForegroundColor Green
+        return
+    }
+
+    if ($outputArg -eq '--load' -and -not $SkipSmokeTest) {
+        Invoke-SmokeTest -Image $image -ExpectedVersion $versionValue
+    }
+
+    Write-Host "Built (not pushed): $image" -ForegroundColor Green
+}
+
+#endregion Build
+
+if ($MyInvocation.InvocationName -ne '.') {
+    try {
+        Invoke-Build
+        exit 0
+    }
+    catch {
+        Write-Error -ErrorAction Continue "build failed: $($_.Exception.Message)"
+        exit 1
+    }
+}

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+#
+# Builds the yamlizr container image locally, and optionally publishes it to ghcr.io.
+#
+# Mirrors the image job in .github/workflows/ci.yml, so a Dockerfile change can be verified
+# before it reaches CI. A local build targets one platform and uses --load, so the image lands
+# in the local engine and is then run: 3.1.6 shipped an image that built cleanly and exited with
+# "No frameworks were found", so building is not evidence that it starts.
+#
+# Usage:
+#   ./build.sh                      build for the host architecture, load it, run it
+#   ./build.sh --push               build every published platform and publish to ghcr.io
+#   ./build.sh --platforms linux/amd64,linux/arm64 --skip-smoke-test
+#   ./build.sh --tag my-test --configuration Debug
+#
+# Requires Docker with buildx. Pushing also requires the gh CLI, and tag resolution uses
+# GitVersion.Tool, which is installed on demand.
+
+set -euo pipefail
+
+REGISTRY="ghcr.io/f2calv"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILDER_NAME="yamlizr1"
+ALL_PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7"
+
+# Mirrored into deps/ for a Debug build, so a fix can be verified before those repos are published.
+DEP_REPOS=("CasCap.Common")
+
+PUSH=false
+CONFIGURATION="Release"
+IMAGE_NAME="yamlizr"
+SKIP_SMOKE_TEST=false
+TAG=""
+VERSION=""
+PLATFORMS=""
+
+usage() {
+  sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --push) PUSH=true; shift ;;
+    --configuration) CONFIGURATION="$2"; shift 2 ;;
+    --tag) TAG="$2"; shift 2 ;;
+    --version) VERSION="$2"; shift 2 ;;
+    --platforms) PLATFORMS="$2"; shift 2 ;;
+    --image-name) IMAGE_NAME="$2"; shift 2 ;;
+    --skip-smoke-test) SKIP_SMOKE_TEST=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+if [[ "$CONFIGURATION" != "Debug" && "$CONFIGURATION" != "Release" ]]; then
+  echo "--configuration must be Debug or Release, got '$CONFIGURATION'." >&2
+  exit 1
+fi
+
+GIT_REPOSITORY="$(basename "$(git -C "$REPO_ROOT" rev-parse --show-toplevel)")"
+GIT_BRANCH="$(git -C "$REPO_ROOT" branch --show-current)"
+GIT_COMMIT="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+
+GITHUB_WORKFLOW="local"
+GITHUB_RUN_ID=0
+GITHUB_RUN_NUMBER=0
+
+install_gitversion() {
+  if command -v dotnet-gitversion >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "dotnet-gitversion not found, installing GitVersion.Tool globally."
+  dotnet tool install -g GitVersion.Tool >/dev/null 2>&1 || return 1
+  export PATH="$HOME/.dotnet/tools:$PATH"
+
+  command -v dotnet-gitversion >/dev/null 2>&1
+}
+
+# The version compiled into the assembly is resolved separately from the image tag. The Dockerfile
+# feeds it to dotnet publish as -p:Version, which rejects a moving label such as "latest-dev".
+resolve_version() {
+  if [[ -n "$VERSION" ]]; then
+    echo "$VERSION"
+    return 0
+  fi
+
+  local resolved=""
+  if install_gitversion; then
+    resolved="$(dotnet-gitversion "$REPO_ROOT" /showvariable SemVer 2>/dev/null | tr -d '[:space:]')"
+  fi
+
+  if [[ -n "$resolved" ]]; then
+    echo "$resolved"
+    return 0
+  fi
+
+  if [[ "$PUSH" == true ]]; then
+    echo "Could not resolve a version from GitVersion, which a push build requires. Pass --version." >&2
+    return 1
+  fi
+
+  # Matches the Dockerfile default, so a local build without GitVersion still succeeds.
+  echo "Could not resolve a version from GitVersion, falling back to 0.0.1." >&2
+  echo "0.0.1"
+}
+
+resolve_platforms() {
+  if [[ -n "$PLATFORMS" ]]; then
+    echo "$PLATFORMS"
+    return 0
+  fi
+
+  if [[ "$PUSH" == true ]]; then
+    echo "$ALL_PLATFORMS"
+    return 0
+  fi
+
+  # --load accepts one platform only, and emulating another is far slower.
+  case "$(uname -m)" in
+    aarch64|arm64) echo "linux/arm64" ;;
+    armv7l|armv6l) echo "linux/arm/v7" ;;
+    *) echo "linux/amd64" ;;
+  esac
+}
+
+# Debug compiles against the local sibling repositories, which a build context cannot reach, so they
+# are mirrored into deps/ first.
+sync_deps() {
+  local parent repo source destination
+  parent="$(dirname "$REPO_ROOT")"
+
+  for repo in "${DEP_REPOS[@]}"; do
+    source="${parent}/${repo}"
+    if [[ ! -d "$source" ]]; then
+      echo "A Debug build needs the sibling repository '${repo}' at '${source}', which was not found. Use --configuration Release instead." >&2
+      exit 1
+    fi
+
+    destination="${REPO_ROOT}/deps/${repo}"
+    echo "Syncing ${repo} -> deps/${repo}"
+    mkdir -p "$destination"
+
+    if command -v rsync >/dev/null 2>&1; then
+      rsync -a --delete \
+        --exclude 'bin/' --exclude 'obj/' --exclude '.git/' --exclude '.vs/' \
+        --exclude 'node_modules/' --exclude 'deps/' \
+        --exclude 'appsettings.Local*.json' --exclude '*.user' \
+        "${source}/" "${destination}/"
+    else
+      rm -rf "${destination:?}"
+      mkdir -p "$destination"
+      tar -C "$source" \
+        --exclude='./bin' --exclude='./obj' --exclude='./.git' --exclude='./.vs' \
+        --exclude='./node_modules' --exclude='./deps' \
+        --exclude='appsettings.Local*.json' --exclude='*.user' \
+        -cf - . | tar -C "$destination" -xf -
+    fi
+  done
+}
+
+connect_ghcr() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI not found. Install it from https://cli.github.com" >&2
+    exit 1
+  fi
+
+  if ! gh auth status 2>&1 | grep -q "write:packages"; then
+    echo "Refreshing gh auth to add the write:packages scope."
+    gh auth refresh -h github.com -s write:packages
+  fi
+
+  local gh_user
+  gh_user="$(gh api user --jq .login)"
+  echo "Authenticating Docker to ghcr.io as ${gh_user}."
+  gh auth token | docker login ghcr.io -u "$gh_user" --password-stdin
+}
+
+initialize_builder() {
+  docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1 \
+    || docker buildx create --name "$BUILDER_NAME" >/dev/null
+  docker buildx use "$BUILDER_NAME"
+}
+
+# A successful build does not prove the image starts.
+smoke_test() {
+  local image="$1"
+  local expected_version="$2"
+
+  echo "Running the image to prove it starts."
+
+  local reported
+  reported="$(docker run --rm "$image" --version | tr -d '\r')"
+
+  # SourceLink may append +<sha> to the informational version, so match the prefix.
+  case "$reported" in
+    "${expected_version}"*) ;;
+    *) echo "Expected a version starting with '${expected_version}', got '${reported}'." >&2; exit 1 ;;
+  esac
+  echo "  reported version: ${reported}"
+
+  docker run --rm "$image" generate --help >/dev/null
+  echo "  generate --help: ok"
+}
+
+main() {
+  local version tag platforms image output_arg dockerfile
+  version="$(resolve_version)"
+  platforms="$(resolve_platforms)"
+
+  if [[ "$CONFIGURATION" == "Debug" ]]; then
+    dockerfile="Dockerfile.Debug"
+  else
+    dockerfile="Dockerfile"
+  fi
+
+  if [[ "$PUSH" == true && "$CONFIGURATION" == "Debug" ]]; then
+    echo "A Debug image is built against unpublished local sources and must not be pushed." >&2
+    exit 1
+  fi
+
+  if [[ -n "$TAG" ]]; then
+    tag="${TAG,,}"
+  elif [[ "$PUSH" == true ]]; then
+    tag="${version,,}"
+  else
+    tag="latest-dev"
+  fi
+
+  image="${REGISTRY}/${IMAGE_NAME,,}:${tag}"
+
+  echo "Image     : ${image}"
+  echo "Version   : ${version}"
+  echo "Platforms : ${platforms}"
+  echo "Dockerfile: ${dockerfile}"
+
+  if [[ "$CONFIGURATION" == "Debug" ]]; then
+    sync_deps
+  fi
+  if [[ "$PUSH" == true ]]; then
+    connect_ghcr
+  fi
+  initialize_builder
+
+  # A multi-architecture manifest cannot be loaded into the local engine.
+  if [[ "$PUSH" == true ]]; then
+    output_arg="--push"
+  elif [[ "$platforms" == *","* ]]; then
+    output_arg="--pull"
+  else
+    output_arg="--load"
+  fi
+
+  docker buildx build \
+    --tag "$image" \
+    --file "${REPO_ROOT}/${dockerfile}" \
+    --build-arg VERSION="$version" \
+    --build-arg CONFIGURATION="$CONFIGURATION" \
+    --build-arg GIT_REPOSITORY="$GIT_REPOSITORY" \
+    --build-arg GIT_BRANCH="$GIT_BRANCH" \
+    --build-arg GIT_COMMIT="$GIT_COMMIT" \
+    --build-arg GIT_TAG="$tag" \
+    --build-arg GITHUB_WORKFLOW="$GITHUB_WORKFLOW" \
+    --build-arg GITHUB_RUN_ID="$GITHUB_RUN_ID" \
+    --build-arg GITHUB_RUN_NUMBER="$GITHUB_RUN_NUMBER" \
+    --platform "$platforms" \
+    "$output_arg" \
+    "$REPO_ROOT"
+
+  if [[ "$PUSH" == true ]]; then
+    echo "Pushed: ${image}"
+    return 0
+  fi
+
+  if [[ "$output_arg" == "--load" && "$SKIP_SMOKE_TEST" == false ]]; then
+    smoke_test "$image" "$version"
+  fi
+
+  echo "Built (not pushed): ${image}"
+}
+
+main "$@"

--- a/src/CasCap.Api.AzureDevOps.Tests/README.md
+++ b/src/CasCap.Api.AzureDevOps.Tests/README.md
@@ -11,17 +11,19 @@ Tests/
 |   |-- YamlPipelineGeneratorTests.cs
 |   `-- PipelineSerializationTests.cs
 `-- Integration/              # Requires a live Azure DevOps organisation
-    |-- TestBase.cs           # Shared configuration, logging and service setup
-    `-- ApiServiceTests.cs
+    |-- TestBase.cs                 # Shared configuration, logging and service setup
+    |-- ApiServiceTests.cs          # Task catalogue retrieval
+    |-- PipelineValidationTests.cs  # Hand-written YAML submitted to the preview endpoint
+    `-- FixtureConversionTests.cs   # Every fixture definition converted, then validated
 ```
 
 ## Test Counts
 
 | Suite | Test methods | Expanded cases |
 | --- | --- | --- |
-| Unit | 10 | 16 |
-| Integration | 1 | 1 |
-| **Total** | **11** | **17** |
+| Unit | 12 | 18 |
+| Integration | 7 | 7 |
+| **Total** | **19** | **25** |
 
 ## Trait Categories
 
@@ -29,38 +31,55 @@ Tests/
 | --- | --- | --- |
 | `Category=Generation` | `YamlPipelineGeneratorTests` | Yes |
 | `Category=Serialization` | `PipelineSerializationTests` | Yes |
-| `Category=Integration` | `ApiServiceTests` | No, excluded with `--filter-not-trait Category=Integration` |
+| `Category=Integration` | `ApiServiceTests`, `PipelineValidationTests`, `FixtureConversionTests` | Yes, when the repository secret is present |
 
 ## Skipped Tests
 
 Integration tests skip rather than fail when no credential is configured, so a contributor without an
-Azure DevOps organisation still gets a green credential-free run. The reported reasons are:
+Azure DevOps organisation still gets a green run, as does a pull request from a fork, which cannot read
+the secret. The reported reasons are:
 
 | Reason | Resolved by |
 | --- | --- |
 | No Azure DevOps token configured | Setting `CasCap:AzureDevOpsOptions:PAT`. |
 | No organisation configured | Setting `CasCap:AzureDevOpsOptions:OrganisationUri`. |
+| No validation pipeline configured | Setting `CasCap:AzureDevOpsOptions:ValidationPipelineId`. |
 
 Integration tests are read-only. They never create, update or delete a definition, task group or
-variable group.
+variable group, and a preview run parses YAML without queueing anything.
 
-## Coverage Gap
+## Validating Generated YAML
 
-The unit tests build their definitions in code, so they verify generator logic but not the conversion
-of a real classic definition. Snapshot tests over the YAML produced from a curated Azure DevOps fixture
-project, run in CI, are tracked in [issue #366](https://github.com/f2calv/yamlizr/issues/366).
+`FixtureConversionTests` converts every `yamlizr.test.*` definition in the fixture organisation and
+submits each result to the Azure DevOps pipeline preview endpoint. That is stronger than a snapshot,
+which only proves the output has not changed: this proves Azure DevOps will accept it. A regression
+fails the build naming the definition, the error Azure DevOps returned, and the generated YAML.
+
+The fixture organisation is built by [.scripts/New-FixtureDefinitions.ps1](../../.scripts/README.md),
+which also creates the `yamlizr.test.validation` pipeline the preview endpoint parses against.
+
+Task groups are inlined for validation, because a relative `template:` reference resolves against the
+target pipeline's repository rather than the submitted document.
 
 ## Running
 
 ```bash
-# credential-free, matching CI
+# everything, which is what CI now runs; integration tests skip without a token
+dotnet test
+
+# credential-free only
 dotnet test --filter-not-trait Category=Integration
 
-# live, after configuring a token
+# live, after configuring the fixture organisation
 dotnet user-secrets set CasCap:AzureDevOpsOptions:PAT "<your token here>"
 dotnet user-secrets set CasCap:AzureDevOpsOptions:OrganisationUri "https://dev.azure.com/myorg"
+dotnet user-secrets set CasCap:AzureDevOpsOptions:Project "myproject"
+dotnet user-secrets set CasCap:AzureDevOpsOptions:ValidationPipelineId "19"
 dotnet test --filter-trait Category=Integration
 ```
+
+The token needs only read access, plus Build (read and execute) for the preview endpoint. It never
+writes to the organisation.
 
 ## Dependencies
 

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/ApiServiceTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/ApiServiceTests.cs
@@ -4,6 +4,8 @@ namespace CasCap.Api.AzureDevOps.Tests.Integration;
 [Trait("Category", "Integration")]
 public class ApiServiceTests : TestBase
 {
+    /// <summary>Initialises the shared Azure DevOps connection.</summary>
+    /// <param name="output">xUnit sink that test logging is written to.</param>
     public ApiServiceTests(ITestOutputHelper output) : base(output) { }
 
     [Fact]

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/FixtureConversionTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/FixtureConversionTests.cs
@@ -1,0 +1,157 @@
+using CasCap.Models;
+using CasCap.Utilities;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.TeamFoundation.DistributedTask.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.ReleaseManagement.WebApi;
+using Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Clients;
+using Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Contracts;
+using Microsoft.VisualStudio.Services.WebApi;
+using System.Collections.Concurrent;
+using TaskGroup = Microsoft.TeamFoundation.DistributedTask.WebApi.TaskGroup;
+using VariableGroup = Microsoft.TeamFoundation.DistributedTask.WebApi.VariableGroup;
+
+namespace CasCap.Api.AzureDevOps.Tests.Integration;
+
+/// <summary>
+/// Converts every fixture definition in the live organisation and asks Azure DevOps to parse the
+/// result, which is the end to end check issue #366 asks for.
+/// </summary>
+/// <remarks>
+/// The hand-written samples in <see cref="PipelineValidationTests"/> prove the endpoint is wired up.
+/// This proves the generator's real output is acceptable, so a regression in the generator fails the
+/// build rather than shipping YAML that Azure DevOps refuses.
+/// <para>
+/// Task groups are inlined, because a relative <c>template:</c> reference resolves against the
+/// target pipeline's repository rather than the submitted document.
+/// </para>
+/// </remarks>
+[Trait("Category", "Integration")]
+public class FixtureConversionTests : TestBase
+{
+    /// <summary>Initialises the shared Azure DevOps connection.</summary>
+    /// <param name="output">xUnit sink that test logging is written to.</param>
+    public FixtureConversionTests(ITestOutputHelper output) : base(output) { }
+
+    /// <summary>Name prefix every object created by <c>.scripts/New-FixtureDefinitions.ps1</c> carries.</summary>
+    private const string FixturePrefix = "yamlizr.test.";
+
+    private const string NotConfiguredForConversion =
+        "No fixture organisation configured, set CasCap:AzureDevOpsOptions:PAT, OrganisationUri, Project and ValidationPipelineId.";
+
+    private bool CanConvert => IsConfigured
+        && Options.ValidationPipelineId.HasValue
+        && !string.IsNullOrWhiteSpace(Options.OrganisationUri)
+        && !string.IsNullOrWhiteSpace(Options.Project);
+
+    [Fact]
+    public async Task EveryFixtureDefinition_ConvertsToYamlThatAzureDevOpsAccepts()
+    {
+        Assert.SkipUnless(CanConvert, NotConfiguredForConversion);
+
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var organisationUri = Options.OrganisationUri.TrimEnd('/');
+
+        using var connection = new VssConnection(new Uri(organisationUri), new VssBasicCredential(string.Empty, Options.PAT));
+        using var buildClient = await connection.GetClientAsync<BuildHttpClient>(cancellationToken);
+        using var releaseClient = await connection.GetClientAsync<ReleaseHttpClient>(cancellationToken);
+        using var taskAgentClient = await connection.GetClientAsync<TaskAgentHttpClient>(cancellationToken);
+
+        var taskMap = await GetTaskMap(organisationUri);
+        var taskGroupMap = await GetTaskGroupMap(taskAgentClient, cancellationToken);
+        var variableGroupMap = (await taskAgentClient.GetVariableGroupsAsync(Options.Project, cancellationToken: cancellationToken))
+            .ToDictionary(k => k.Id, v => v);
+
+        var converted = 0;
+        var failures = new List<string>();
+
+        foreach (var reference in await buildClient.GetDefinitionsAsync(Options.Project, cancellationToken: cancellationToken))
+        {
+            if (!reference.Name.StartsWith(FixturePrefix, StringComparison.OrdinalIgnoreCase)) continue;
+
+            var definition = await buildClient.GetDefinitionAsync(Options.Project, reference.Id, cancellationToken: cancellationToken);
+
+            //the validation pipeline itself is YAML, and only a classic definition converts
+            if (definition.Process is not DesignerProcess) continue;
+
+            var yaml = Convert(definition, null, taskMap, taskGroupMap, variableGroupMap);
+            if (yaml is null) continue;
+
+            converted++;
+            await Validate(definition.Name, yaml, failures, cancellationToken);
+        }
+
+        foreach (var reference in await releaseClient.GetReleaseDefinitionsAsync(Options.Project, cancellationToken: cancellationToken))
+        {
+            if (!reference.Name.StartsWith(FixturePrefix, StringComparison.OrdinalIgnoreCase)) continue;
+
+            var definition = await releaseClient.GetReleaseDefinitionAsync(Options.Project, reference.Id, cancellationToken: cancellationToken);
+
+            var yaml = Convert(null, definition, taskMap, taskGroupMap, variableGroupMap);
+            if (yaml is null) continue;
+
+            converted++;
+            await Validate(definition.Name, yaml, failures, cancellationToken);
+        }
+
+        Assert.True(converted > 0, $"No definitions named '{FixturePrefix}*' were found, so nothing was validated.");
+        Assert.True(failures.Count == 0, string.Join(Environment.NewLine + Environment.NewLine, failures));
+    }
+
+    private static string Convert(
+        BuildDefinition build,
+        ReleaseDefinition release,
+        Dictionary<Guid, Dictionary<int, TaskObj>> taskMap,
+        Dictionary<TaskGroupVersion, TaskGroup> taskGroupMap,
+        Dictionary<int, VariableGroup> variableGroupMap)
+    {
+        var generator = new YamlPipelineGenerator(
+            build,
+            release,
+            taskMap,
+            taskGroupMap,
+            new ConcurrentDictionary<TaskGroupVersion, Template>(),
+            variableGroupMap,
+            inlineTaskGroups: true,
+            DeployPhaseTypes.AgentBasedDeployment);
+
+        return generator.GenPipeline()?.ToString();
+    }
+
+    private async Task Validate(string name, string yaml, List<string> failures, CancellationToken cancellationToken)
+    {
+        var result = await _apiSvc.Validate(
+            Options.OrganisationUri, Options.Project, Options.ValidationPipelineId.Value, yaml, cancellationToken);
+
+        if (!result.IsValid) failures.Add($"'{name}' was rejected: {result.Message}{Environment.NewLine}{yaml}");
+    }
+
+    private async Task<Dictionary<Guid, Dictionary<int, TaskObj>>> GetTaskMap(string organisationUri)
+    {
+        var extensions = await _apiSvc.GetAllExtensions(organisationUri);
+        foreach (var extension in extensions)
+            extension.inputMap = extension.inputs.ToDictionary(k => k.name, v => v);
+
+        var taskMap = new Dictionary<Guid, Dictionary<int, TaskObj>>();
+        foreach (var id in extensions.Select(p => p.id).Distinct())
+        {
+            //a duplicated id means an incorrectly installed extension, which the tool also tolerates
+            var byMajorVersion = extensions.Where(p => p.id == id).ToDictionary(k => k.version.major, v => v);
+            taskMap.TryAdd(id, byMajorVersion);
+        }
+
+        return taskMap;
+    }
+
+    private async Task<Dictionary<TaskGroupVersion, TaskGroup>> GetTaskGroupMap(
+        TaskAgentHttpClient taskAgentClient, CancellationToken cancellationToken)
+    {
+        var taskGroups = await taskAgentClient.GetTaskGroupsAsync(Options.Project, cancellationToken: cancellationToken);
+
+        var map = new Dictionary<TaskGroupVersion, TaskGroup>();
+        foreach (var taskGroup in taskGroups)
+            map[new TaskGroupVersion(taskGroup.Id, taskGroup.Version.Major)] = taskGroup;
+
+        return map;
+    }
+}

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/PipelineValidationTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/PipelineValidationTests.cs
@@ -1,0 +1,116 @@
+using CasCap.Models;
+
+namespace CasCap.Api.AzureDevOps.Tests.Integration;
+
+/// <summary>
+/// Submits YAML to the Azure DevOps pipeline preview endpoint, which parses it and expands its
+/// templates without queueing anything.
+/// </summary>
+/// <remarks>
+/// A schema check proves a document is well formed; this proves Azure DevOps will accept it, which
+/// is the only claim that matters for generated output. See issue #366.
+/// </remarks>
+[Trait("Category", "Integration")]
+public class PipelineValidationTests : TestBase
+{
+    /// <summary>Initialises the shared Azure DevOps connection.</summary>
+    /// <param name="output">xUnit sink that test logging is written to.</param>
+    public PipelineValidationTests(ITestOutputHelper output) : base(output) { }
+
+    private const string NoValidationPipeline =
+        "No validation pipeline configured, set CasCap:AzureDevOpsOptions:ValidationPipelineId to the id of yamlizr.test.validation.";
+
+    private bool CanValidate => IsConfigured
+        && Options.ValidationPipelineId.HasValue
+        && !string.IsNullOrWhiteSpace(Options.OrganisationUri)
+        && !string.IsNullOrWhiteSpace(Options.Project);
+
+    [Fact]
+    public async Task WellFormedYaml_IsAccepted()
+    {
+        Assert.SkipUnless(CanValidate, NoValidationPipeline);
+
+        var result = await Validate("""
+            pool:
+              vmImage: ubuntu-latest
+            steps:
+            - script: echo hello
+              displayName: Say hello
+            """);
+
+        Assert.True(result.IsValid, result.Message);
+        Assert.NotEmpty(result.FinalYaml);
+    }
+
+    //the generator emitted exactly this until the identifier sanitiser was added
+    [Fact]
+    public async Task JobNameWithAnIllegalCharacter_IsRejected()
+    {
+        Assert.SkipUnless(CanValidate, NoValidationPipeline);
+
+        var result = await Validate("""
+            pool:
+              vmImage: ubuntu-latest
+            jobs:
+            - job: Phase three, fan-in
+              steps:
+              - script: echo hello
+            """);
+
+        Assert.False(result.IsValid);
+        Assert.Contains("invalid name", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    //the generator emitted exactly this until template parameters became a sequence
+    [Fact]
+    public async Task TemplateParametersAsAMapping_AreRejected()
+    {
+        Assert.SkipUnless(CanValidate, NoValidationPipeline);
+
+        var result = await Validate("""
+            parameters:
+              greeting: hello
+            steps:
+            - script: echo ${{ parameters.greeting }}
+            """);
+
+        Assert.False(result.IsValid);
+        Assert.Contains("mapping was not expected", result.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GeneratedIdentifiers_AreAccepted()
+    {
+        Assert.SkipUnless(CanValidate, NoValidationPipeline);
+
+        //mirrors the shape yamlizr now emits for a multi-phase build, including a fan-in
+        var result = await Validate("""
+            pool:
+              vmImage: ubuntu-latest
+            jobs:
+            - job: Phase_one_0
+              displayName: Phase one
+              steps:
+              - script: echo one
+            - job: Phase_two_1
+              displayName: Phase two
+              dependsOn:
+              - Phase_one_0
+              steps:
+              - script: echo two
+            - job: Phase_three_fan_in_2
+              displayName: Phase three, fan-in
+              dependsOn:
+              - Phase_one_0
+              - Phase_two_1
+              condition: succeededOrFailed()
+              steps:
+              - script: echo three
+            """);
+
+        Assert.True(result.IsValid, result.Message);
+    }
+
+    private Task<PipelineValidationResult> Validate(string yaml)
+        => _apiSvc.Validate(Options.OrganisationUri, Options.Project, Options.ValidationPipelineId.Value, yaml, TestContext.Current.CancellationToken);
+}

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/PipelineValidationTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/PipelineValidationTests.cs
@@ -111,6 +111,38 @@ public class PipelineValidationTests : TestBase
         Assert.True(result.IsValid, result.Message);
     }
 
+    /// <summary>
+    /// Converts a definition whose phase names contain characters that are illegal in a YAML
+    /// identifier, then asks Azure DevOps to parse the result.
+    /// </summary>
+    /// <remarks>
+    /// The only test that runs the generator and validates what it actually produced. The samples
+    /// above would still pass if the generator regressed, because they are hand written; this one
+    /// fails, which is what makes it a regression test rather than a demonstration.
+    /// </remarks>
+    [Fact]
+    public async Task GeneratedYaml_ForPhaseNamesNeedingSanitising_IsAccepted()
+    {
+        Assert.SkipUnless(CanValidate, NoValidationPipeline);
+
+        //CmdLine really exists, because Azure DevOps rejects a reference to a task it cannot resolve
+        var taskMap = YamlizrTestData.TaskMap("CmdLine", 2, "script");
+        var step = YamlizrTestData.Step(
+            YamlizrTestData.KnownTaskId,
+            versionSpec: "2.*",
+            inputs: new Dictionary<string, string> { ["script"] = "echo hello" });
+
+        var definition = YamlizrTestData.BuildDefinitionWithPhases(
+            "Azure Pipelines", step, "Phase one", "Phase two", "Phase three, fan-in");
+
+        var pipeline = YamlizrTestData.Generator(definition, taskMap).GenPipeline();
+        var yaml = pipeline.ToString();
+
+        var result = await Validate(yaml);
+
+        Assert.True(result.IsValid, $"{result.Message}{Environment.NewLine}{yaml}");
+    }
+
     private Task<PipelineValidationResult> Validate(string yaml)
         => _apiSvc.Validate(Options.OrganisationUri, Options.Project, Options.ValidationPipelineId.Value, yaml, TestContext.Current.CancellationToken);
 }

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/TestBase.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/TestBase.cs
@@ -31,6 +31,8 @@ public abstract class TestBase : IDisposable
     protected const string NotConfigured =
         "No Azure DevOps token configured, set CasCap:AzureDevOpsOptions:PAT via user secrets or CasCap__AzureDevOpsOptions__PAT.";
 
+    /// <summary>Builds configuration and, when a token is available, the client under test.</summary>
+    /// <param name="output">xUnit sink that test logging is written to.</param>
     protected TestBase(ITestOutputHelper output)
     {
         var configuration = new ConfigurationBuilder()

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/TestBase.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/TestBase.cs
@@ -1,4 +1,5 @@
-﻿using CasCap.Models;
+﻿using CasCap.Abstractions;
+using CasCap.Models;
 using CasCap.Services;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Unit/YamlPipelineGeneratorTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Unit/YamlPipelineGeneratorTests.cs
@@ -115,6 +115,30 @@ public class YamlPipelineGeneratorTests
     }
 
     [Fact]
+    public void GenPipeline_MultipleEnvironments_NamesEachStageAfterItsEnvironment()
+    {
+        var generator = YamlizrTestData.Generator(YamlizrTestData.ReleaseDefinition("Dev", "Test", "Prod"));
+
+        var pipeline = generator.GenPipeline();
+
+        Assert.NotNull(pipeline.stages);
+        Assert.Equal(["Dev", "Test", "Prod"], pipeline.stages.Select(p => p.stage));
+        //the release definition names the document, so repeating it on every stage loses the environment
+        Assert.Equal(["Dev", "Test", "Prod"], pipeline.stages.Select(p => p.displayName));
+    }
+
+    [Fact]
+    public void GenPipeline_EnvironmentWithoutAName_FallsBackToTheStageIdentifier()
+    {
+        var generator = YamlizrTestData.Generator(YamlizrTestData.ReleaseDefinition("Dev", "   "));
+
+        var pipeline = generator.GenPipeline();
+
+        var unnamed = Assert.Single(pipeline.stages, p => p.stage == "Stage_2");
+        Assert.Equal("Stage_2", unnamed.displayName);
+    }
+
+    [Fact]
     public void GenPipeline_NeitherBuildNorRelease_IsRejected()
     {
         var generator = new YamlPipelineGenerator(

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Unit/YamlPipelineGeneratorTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Unit/YamlPipelineGeneratorTests.cs
@@ -138,6 +138,24 @@ public class YamlPipelineGeneratorTests
         Assert.Equal("Stage_2", unnamed.displayName);
     }
 
+    //a job identifier must match [A-Za-z_][A-Za-z0-9_]*, and Azure DevOps rejects the pipeline otherwise
+    [Theory]
+    [InlineData("Phase three, fan-in")]
+    [InlineData("build & test")]
+    [InlineData("  leading and trailing  ")]
+    [InlineData("1st phase")]
+    public void GenPipeline_PhaseNameNeedingSanitising_ProducesAValidJobIdentifier(string phaseName)
+    {
+        var definition = YamlizrTestData.BuildDefinitionWithPhases(
+            "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), "Phase one", phaseName);
+
+        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+
+        Assert.NotNull(pipeline.jobs);
+        //asserts the contract rather than an exact name, which also carries the issue #368 index suffix
+        Assert.All(pipeline.jobs, p => Assert.Matches("^[A-Za-z_][A-Za-z0-9_]*$", p.job));
+    }
+
     [Fact]
     public void GenPipeline_NeitherBuildNorRelease_IsRejected()
     {

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/YamlizrTestData.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/YamlizrTestData.cs
@@ -54,23 +54,64 @@ public static class YamlizrTestData
     }
 
     /// <summary>Builds a single enabled step referencing the supplied task id and version spec.</summary>
-    public static BuildDefinitionStep Step(Guid taskId, string versionSpec = "1.*", string displayName = "sample step")
+    public static BuildDefinitionStep Step(Guid taskId, string versionSpec = "1.*", string displayName = "sample step", IDictionary<string, string> inputs = null)
         => new()
         {
             Enabled = true,
             DisplayName = displayName,
             TaskDefinition = new TaskDefinitionReference { Id = taskId, VersionSpec = versionSpec, DefinitionType = "task" },
+            Inputs = inputs ?? new Dictionary<string, string>(),
         };
 
+    /// <summary>Builds a classic designer build definition with one agent phase per supplied name.</summary>
+    /// <remarks>
+    /// More than one phase is required for the generator to emit jobs; a single phase is flattened to
+    /// a bare step list, which hides the job identifier. Each phase depends on the one before it.
+    /// </remarks>
+    /// <param name="queueName">Agent queue name, emitted as the pipeline pool.</param>
+    /// <param name="step">The step every phase carries.</param>
+    /// <param name="phaseNames">Phase names, in order.</param>
+    public static BuildDefinition BuildDefinitionWithPhases(string queueName, BuildDefinitionStep step, params string[] phaseNames)
+    {
+        var process = new DesignerProcess();
+
+        for (var i = 0; i < phaseNames.Length; i++)
+        {
+            var phase = new Phase
+            {
+                Name = phaseNames[i],
+                RefName = $"Phase_{i + 1}",
+                Condition = "succeeded()",
+                Target = new AgentPoolQueueTarget(),
+                Steps = [step],
+            };
+
+            if (i > 0) phase.Dependencies.Add(new Dependency { Scope = $"Phase_{i}", Event = "Completed" });
+            process.Phases.Add(phase);
+        }
+
+        return new BuildDefinition
+        {
+            Id = 43,
+            Name = "sample multi phase build",
+            Queue = new AgentPoolQueue { Name = queueName },
+            Process = process,
+        };
+    }
+
     /// <summary>Builds a task map containing one installed task, keyed the way the generator expects.</summary>
-    public static Dictionary<Guid, Dictionary<int, TaskObj>> TaskMap(string taskName = "SampleTask", int major = 1)
+    /// <remarks>
+    /// Naming a task that really exists matters when the generated YAML is submitted to Azure DevOps,
+    /// which rejects a reference to a task it cannot resolve.
+    /// </remarks>
+    public static Dictionary<Guid, Dictionary<int, TaskObj>> TaskMap(string taskName = "SampleTask", int major = 1, params string[] inputNames)
     {
         var task = new TaskObj
         {
             id = KnownTaskId,
             name = taskName,
             version = new CasCap.Models.TaskVersion { major = major },
-            inputs = [],
+            inputs = [.. inputNames.Select(p => new TaskInput { name = p })],
         };
         task.inputMap = task.inputs.ToDictionary(k => k.name, v => v);
         return new Dictionary<Guid, Dictionary<int, TaskObj>> { [KnownTaskId] = new() { [major] = task } };

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/YamlizrTestData.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/YamlizrTestData.cs
@@ -3,6 +3,7 @@ using CasCap.Models;
 using CasCap.Utilities;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.VisualStudio.Services.ReleaseManagement.WebApi;
+using Microsoft.VisualStudio.Services.ReleaseManagement.WebApi.Contracts;
 using System.Collections.Concurrent;
 using TaskDefinitionReference = Microsoft.TeamFoundation.Build.WebApi.TaskDefinitionReference;
 using TaskGroup = Microsoft.TeamFoundation.DistributedTask.WebApi.TaskGroup;
@@ -80,6 +81,67 @@ public static class YamlizrTestData
         => new(
             build,
             null,
+            taskMap ?? TaskMap(),
+            new Dictionary<TaskGroupVersion, TaskGroup>(),
+            new ConcurrentDictionary<TaskGroupVersion, Template>(),
+            new Dictionary<int, VariableGroup>(),
+            inlineTaskGroups: false,
+            DeployPhaseTypes.AgentBasedDeployment);
+
+    /// <summary>Builds a classic release definition with one agent-based deploy phase per named environment.</summary>
+    /// <param name="environmentNames">Environment names, in rank order.</param>
+    public static ReleaseDefinition ReleaseDefinition(params string[] environmentNames)
+    {
+        //the SDK leaves these collections null, unlike the build definition equivalents
+        var definition = new ReleaseDefinition
+        {
+            Id = 7,
+            Name = "sample release",
+            Environments = [],
+        };
+
+        var rank = 1;
+        foreach (var environmentName in environmentNames)
+        {
+            var environment = new ReleaseDefinitionEnvironment
+            {
+                Name = environmentName,
+                Rank = rank,
+                DeployPhases = [],
+                Variables = new Dictionary<string, ConfigurationVariableValue>(),
+                VariableGroups = [],
+            };
+
+            environment.DeployPhases.Add(new AgentBasedDeployPhase
+            {
+                Name = "Agent job",
+                Rank = 1,
+                DeploymentInput = new AgentDeploymentInput { Condition = "succeeded()" },
+                WorkflowTasks =
+                {
+                    new WorkflowTask
+                    {
+                        Enabled = true,
+                        Name = "sample step",
+                        TaskId = KnownTaskId,
+                        Version = "1.*",
+                        DefinitionType = "task",
+                    }
+                }
+            });
+
+            definition.Environments.Add(environment);
+            rank++;
+        }
+
+        return definition;
+    }
+
+    /// <summary>Creates a generator over a release definition with no task groups or variable groups.</summary>
+    public static YamlPipelineGenerator Generator(ReleaseDefinition release, Dictionary<Guid, Dictionary<int, TaskObj>> taskMap = null)
+        => new(
+            null,
+            release,
             taskMap ?? TaskMap(),
             new Dictionary<TaskGroupVersion, TaskGroup>(),
             new ConcurrentDictionary<TaskGroupVersion, Template>(),

--- a/src/CasCap.Api.AzureDevOps.Tests/appsettings.Test.json
+++ b/src/CasCap.Api.AzureDevOps.Tests/appsettings.Test.json
@@ -3,7 +3,8 @@
     "AzureDevOpsOptions": {
       "PAT": null, //supply via user secrets or CasCap__AzureDevOpsOptions__PAT
       "OrganisationUri": null, //e.g. https://dev.azure.com/myorg
-      "Project": null
+      "Project": null,
+      "ValidationPipelineId": null //id of the yamlizr.test.validation YAML pipeline
     }
   }
 }

--- a/src/CasCap.Api.AzureDevOps/Abstractions/IApiService.cs
+++ b/src/CasCap.Api.AzureDevOps/Abstractions/IApiService.cs
@@ -14,11 +14,29 @@ public interface IApiService
     /// <returns>Every installed task, or null when the response carried none.</returns>
     Task<List<TaskObj>> GetAllExtensions(string organisationUri);
 
-    /// <summary>Asks Azure DevOps to validate a YAML document without queueing a run.</summary>
-    /// <param name="organisation">Organisation name, the segment after <c>dev.azure.com/</c>.</param>
+    /// <summary>Asks Azure DevOps to parse a YAML document without queueing a run.</summary>
+    /// <remarks>
+    /// Wraps the pipeline preview endpoint, which expands templates and reports the first parse error.
+    /// The target pipeline must exist, must be a YAML pipeline, and must be enabled; a disabled one
+    /// fails the call outright. Its own YAML is irrelevant because <paramref name="pipelineYaml"/>
+    /// replaces it.
+    /// <para>
+    /// Relative <c>template:</c> references resolve against the target pipeline's repository, not the
+    /// submitted document, so generated YAML that references a task group template only validates
+    /// when those templates are committed, or when it was generated with task groups inlined.
+    /// </para>
+    /// <para>See <see href="https://learn.microsoft.com/rest/api/azure/devops/pipelines/preview/preview" />.</para>
+    /// </remarks>
+    /// <param name="organisationUri">Absolute organisation Uri, for example <c>https://dev.azure.com/myorg</c>.</param>
     /// <param name="project">Team project name.</param>
-    /// <param name="pipelineId">Identifier of an existing YAML pipeline to preview against.</param>
+    /// <param name="pipelineId">Identifier of an existing, enabled YAML pipeline to preview against.</param>
     /// <param name="pipelineYaml">The document to validate.</param>
-    /// <returns>The preview response body, or null when the call returned none.</returns>
-    Task<string> Validate(string organisation, string project, int pipelineId, string pipelineYaml);
+    /// <param name="cancellationToken">Token to cancel the call.</param>
+    /// <returns>Whether the document parsed, with either the expanded YAML or the rejection reason.</returns>
+    Task<PipelineValidationResult> Validate(
+        string organisationUri,
+        string project,
+        int pipelineId,
+        string pipelineYaml,
+        CancellationToken cancellationToken = default);
 }

--- a/src/CasCap.Api.AzureDevOps/Abstractions/IApiService.cs
+++ b/src/CasCap.Api.AzureDevOps/Abstractions/IApiService.cs
@@ -1,0 +1,24 @@
+using CasCap.Models;
+
+namespace CasCap.Abstractions;
+
+/// <summary>Azure DevOps REST calls that the official client libraries do not cover.</summary>
+public interface IApiService
+{
+    /// <summary>Retrieves every task installed in the organisation.</summary>
+    /// <remarks>
+    /// The classic definition names a task only by identifier and version spec, so this catalogue is
+    /// what resolves it to the <c>Name@Major</c> reference a YAML step needs.
+    /// </remarks>
+    /// <param name="organisationUri">Absolute organisation Uri, for example <c>https://dev.azure.com/myorg</c>.</param>
+    /// <returns>Every installed task, or null when the response carried none.</returns>
+    Task<List<TaskObj>> GetAllExtensions(string organisationUri);
+
+    /// <summary>Asks Azure DevOps to validate a YAML document without queueing a run.</summary>
+    /// <param name="organisation">Organisation name, the segment after <c>dev.azure.com/</c>.</param>
+    /// <param name="project">Team project name.</param>
+    /// <param name="pipelineId">Identifier of an existing YAML pipeline to preview against.</param>
+    /// <param name="pipelineYaml">The document to validate.</param>
+    /// <returns>The preview response body, or null when the call returned none.</returns>
+    Task<string> Validate(string organisation, string project, int pipelineId, string pipelineYaml);
+}

--- a/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/PipelineValidationResult.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/PipelineValidationResult.cs
@@ -1,0 +1,21 @@
+namespace CasCap.Models;
+
+/// <summary>Outcome of submitting a YAML document to the Azure DevOps pipeline preview endpoint.</summary>
+/// <remarks>
+/// A preview parses the document and expands its templates without queueing anything, so it is the
+/// closest thing to a compiler for a generated pipeline. It is stricter than a schema check in some
+/// places and looser in others: an invalid job identifier is rejected, while <c>variables: []</c> is
+/// accepted even though the editor schema flags it.
+/// </remarks>
+public record PipelineValidationResult
+{
+    /// <summary>True when Azure DevOps parsed the document successfully.</summary>
+    public bool IsValid { get; init; }
+
+    /// <summary>The document with every template expanded, populated only when <see cref="IsValid"/> is true.</summary>
+    public string FinalYaml { get; init; }
+
+    /// <summary>Why the document was rejected, populated only when <see cref="IsValid"/> is false.</summary>
+    /// <remarks>Carries the file, line and column when Azure DevOps reports them.</remarks>
+    public string Message { get; init; }
+}

--- a/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/TaskGroupVersion.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/TaskGroupVersion.cs
@@ -1,13 +1,25 @@
 ﻿namespace CasCap.Models;
 
+/// <summary>Identifies one version of a task group.</summary>
+/// <remarks>
+/// Used as a dictionary key while converting. A single definition may reference several versions of
+/// the same task group, and each version produces its own template file, so the identifier alone is
+/// not enough to key one.
+/// </remarks>
 public readonly struct TaskGroupVersion
 {
+    /// <summary>Creates a key for a specific version of a task group.</summary>
+    /// <param name="_taskGroupId">Identifier of the task group.</param>
+    /// <param name="_version">Major version the referencing step pinned.</param>
     public TaskGroupVersion(Guid _taskGroupId, int _version)
     {
         taskGroupId = _taskGroupId;
         version = _version;
     }
 
+    /// <summary>Identifier of the task group.</summary>
     public Guid taskGroupId { get; }
+
+    /// <summary>Major version the referencing step pinned.</summary>
     public int version { get; }
 }

--- a/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/TaskInput.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/TaskInput.cs
@@ -1,17 +1,42 @@
 ﻿namespace CasCap.Models;
 
+/// <summary>One declared input of an Azure Pipelines task.</summary>
+/// <remarks>
+/// Read from the task catalogue so a classic step's supplied values can be matched against what the
+/// task actually declares. An input left at its declared default is omitted from the generated YAML.
+/// </remarks>
 public class TaskInput
 {
+    /// <summary>True when the task refuses to run without a value for this input.</summary>
     public bool required { get; set; }
+
+    /// <summary>Permitted values, keyed by value, for an input rendered as a pick list.</summary>
     public Dictionary<string, string> options { get; set; }
+
+    /// <summary>Alternative names accepted for this input, which a classic definition may have used.</summary>
     public List<string> aliases { get; set; }
+
+    /// <summary>Value used when a step supplies none.</summary>
     public string defaultValue { get; set; }
+
+    /// <summary>Name of the group this input is displayed under in the classic editor.</summary>
     public string groupName { get; set; }
+
+    /// <summary>Help text shown beside the input, in Markdown.</summary>
     public string helpMarkDown { get; set; }
+
+    /// <summary>Label shown beside the input in the classic editor.</summary>
     public string label { get; set; }
+
+    /// <summary>Name the step uses to supply a value, and the key emitted under <c>inputs</c>.</summary>
     public string name { get; set; }
+
+    /// <summary>Input type, for example <c>string</c>, <c>boolean</c>, <c>picklist</c> or <c>filePath</c>.</summary>
     public string type { get; set; }
+
+    /// <summary>Expression controlling whether the classic editor shows this input.</summary>
     public string visibleRule { get; set; }
 
+    /// <inheritdoc/>
     public override string ToString() => $"{name}";
 }

--- a/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/TaskObj.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/TaskObj.cs
@@ -1,32 +1,92 @@
 ﻿namespace CasCap.Models;
 
+/// <summary>One task in the organisation's task catalogue.</summary>
+/// <remarks>
+/// A classic step names a task only by <see cref="id"/> and a version spec, so the catalogue is what
+/// turns that into the <c>Task@Major</c> reference a YAML step needs. A step whose task is absent
+/// from the catalogue cannot be converted, which is the reported case where an extension supplying
+/// it was uninstalled.
+/// </remarks>
 public class TaskObj
 {
+    /// <summary>True when the task's implementation has been uploaded to the organisation.</summary>
     public bool contentsUploaded { get; set; }
+
+    /// <summary>True when the task still runs but should no longer be used in new definitions.</summary>
     public bool deprecated { get; set; }
+
+    /// <summary>True when the task is published as a preview.</summary>
     public bool preview { get; set; }
+
+    /// <summary>True when the task ships with Azure DevOps rather than an installed extension.</summary>
     public bool serverOwned { get; set; }
+
+    /// <summary>True when the task's inputs are also exposed to the step as environment variables.</summary>
     public bool showEnvironmentVariables { get; set; }
+
+    /// <summary>The entries of <see cref="inputs"/> keyed by <see cref="TaskInput.name"/>, for lookup.</summary>
     public Dictionary<string, TaskInput> inputMap { get; set; }
+
+    /// <summary>Identifier a classic step uses to reference this task.</summary>
     public Guid id { get; set; }
+
+    /// <summary>Agent capabilities the task requires.</summary>
     public List<string> demands { get; set; }
+
+    /// <summary>Execution targets the task supports, for example <c>Agent</c> or <c>DeploymentGroup</c>.</summary>
     public List<string> runsOn { get; set; }
+
+    /// <summary>Demands this task satisfies for later tasks in the same job.</summary>
     public List<string> satisfies { get; set; }
+
+    /// <summary>Definition types the task may appear in, for example <c>Build</c> or <c>Release</c>.</summary>
     public List<string> visibility { get; set; }
+
+    /// <summary>Inputs the task declares.</summary>
     public List<TaskInput> inputs { get; set; }
+
+    /// <summary>Publisher of the task.</summary>
     public string author { get; set; }
+
+    /// <summary>Category the task is grouped under in the classic editor, for example <c>Build</c>.</summary>
     public string category { get; set; }
+
+    /// <summary>Identifier of the extension contribution supplying the task, when it is not in-box.</summary>
     public string contributionIdentifier { get; set; }
+
+    /// <summary>Version of the extension contribution supplying the task.</summary>
     public string contributionVersion { get; set; }
+
+    /// <summary>Kind of definition this entry describes, which is <c>task</c> for a task and <c>metaTask</c> for a task group.</summary>
     public string definitionType { get; set; }
+
+    /// <summary>Description shown in the classic editor.</summary>
     public string description { get; set; }
+
+    /// <summary>Display name shown in the classic editor, which differs from <see cref="name"/> for several in-box tasks.</summary>
     public string friendlyName { get; set; }
+
+    /// <summary>Help text shown beside the task, in Markdown.</summary>
     public string helpMarkDown { get; set; }
+
+    /// <summary>Link to the task's documentation.</summary>
     public string helpUrl { get; set; }
+
+    /// <summary>Link to the icon shown beside the task.</summary>
     public string iconUrl { get; set; }
+
+    /// <summary>Template producing a step's display name when the definition supplies none.</summary>
     public string instanceNameFormat { get; set; }
+
+    /// <summary>Lowest agent version able to run the task.</summary>
     public string minimumAgentVersion { get; set; }
+
+    /// <summary>Name emitted in a YAML step reference, as the <c>Name</c> half of <c>Name@Major</c>.</summary>
     public string name { get; set; }
+
+    /// <summary>Release notes for the installed version.</summary>
     public string releaseNotes { get; set; }
+
+    /// <summary>Version installed in the organisation.</summary>
     public TaskVersion version { get; set; }
 }

--- a/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/TaskVersion.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/TaskVersion.cs
@@ -1,8 +1,19 @@
 ﻿namespace CasCap.Models;
 
+/// <summary>Version of an Azure Pipelines task, as reported by the organisation's task catalogue.</summary>
+/// <remarks>
+/// A classic step pins a task by major version only, through a <c>N.*</c> version spec, so the minor
+/// and patch components describe what the organisation currently has installed rather than what the
+/// definition asked for.
+/// </remarks>
 public class TaskVersion
 {
+    /// <summary>Major version, the only component a classic version spec pins.</summary>
     public int major { get; set; }
+
+    /// <summary>Minor version of the installed task.</summary>
     public int minor { get; set; }
+
+    /// <summary>Patch version of the installed task.</summary>
     public int patch { get; set; }
 }

--- a/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/Tasks.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/Tasks.cs
@@ -1,7 +1,16 @@
 ﻿namespace CasCap.Models;
 
+/// <summary>Response envelope returned by the Azure DevOps task catalogue endpoint.</summary>
+/// <remarks>
+/// Retrieved by <see cref="CasCap.Services.IApiService.GetAllExtensions(string)"/> from
+/// <c>_apis/distributedtask/tasks</c>. The catalogue is the only way to resolve the task identifier
+/// a classic step carries into the <c>Task@Major</c> form a YAML step needs.
+/// </remarks>
 public class Tasks
 {
+    /// <summary>Number of tasks returned in <see cref="value"/>.</summary>
     public int count { get; set; }
+
+    /// <summary>Every task installed in the organisation, both in-box and extension supplied.</summary>
     public List<TaskObj> value { get; set; }
 }

--- a/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/Tasks.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/AzureDevOps/Tasks.cs
@@ -2,7 +2,7 @@
 
 /// <summary>Response envelope returned by the Azure DevOps task catalogue endpoint.</summary>
 /// <remarks>
-/// Retrieved by <see cref="CasCap.Services.IApiService.GetAllExtensions(string)"/> from
+/// Retrieved by <see cref="CasCap.Abstractions.IApiService.GetAllExtensions(string)"/> from
 /// <c>_apis/distributedtask/tasks</c>. The catalogue is the only way to resolve the task identifier
 /// a classic step carries into the <c>Task@Major</c> form a YAML step needs.
 /// </remarks>

--- a/src/CasCap.Api.AzureDevOps/Models/AzureDevOpsOptions.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/AzureDevOpsOptions.cs
@@ -26,4 +26,13 @@ public record AzureDevOpsOptions
     /// <summary>Name of the Azure DevOps team project to convert.</summary>
     [MinLength(1)]
     public string Project { get; init; }
+
+    /// <summary>Identifier of a YAML pipeline used only as a target for validating generated YAML.</summary>
+    /// <remarks>
+    /// The pipeline preview endpoint needs an existing, enabled YAML pipeline to parse against, and
+    /// its own YAML is replaced by the document being validated. Null disables validation.
+    /// <para>Created by <c>.scripts/New-FixtureDefinitions.ps1</c>.</para>
+    /// </remarks>
+    [Range(1, int.MaxValue)]
+    public int? ValidationPipelineId { get; init; }
 }

--- a/src/CasCap.Api.AzureDevOps/Models/Yaml/Pipeline.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/Yaml/Pipeline.cs
@@ -2,23 +2,68 @@
 
 namespace CasCap.Models;
 
+/// <summary>Root of a generated Azure Pipelines YAML document.</summary>
+/// <remarks>
+/// Property order is the serialised order, so members are declared in the order the Azure Pipelines
+/// schema conventionally presents them rather than alphabetically. Only one of <see cref="stages"/>,
+/// <see cref="jobs"/> and <see cref="steps"/> is populated, because a document that mixes them is
+/// rejected.
+/// <para>See <see href="https://learn.microsoft.com/azure/devops/pipelines/yaml-schema" />.</para>
+/// </remarks>
 public class Pipeline
 {
+    /// <summary>Build number format, emitted as the pipeline <c>name</c>.</summary>
     public string name { get; set; }
+
+    /// <summary>Parameters this document declares when it is used as a template.</summary>
+    /// <remarks>A sequence, not a mapping; see <see cref="TemplateParameter"/>.</remarks>
     public List<TemplateParameter> parameters { get; set; }
+
+    /// <summary>Container image every job runs in.</summary>
     public string container { get; set; }
+
+    /// <summary>Repositories, containers and pipelines the run consumes.</summary>
     public Resources resources { get; set; }
+
+    /// <summary>Continuous integration trigger.</summary>
     public TriggerAzDO trigger { get; set; }
+
+    /// <summary>Pull request trigger.</summary>
     public TriggerAzDO pr { get; set; }
+
+    /// <summary>Scheduled triggers.</summary>
     public Schedule[] schedules { get; set; }
+
+    /// <summary>Agent pool every job runs on unless it overrides this.</summary>
     public Pool pool { get; set; }
+
+    /// <summary>Matrix or parallel execution strategy.</summary>
     public Strategy strategy { get; set; }
+
+    /// <summary>Pipeline-scoped variables, including linked variable groups.</summary>
+    /// <remarks>Omitted entirely when empty, because <c>variables: []</c> is rejected by the schema.</remarks>
     public List<Variable> variables { get; set; }
+
+    /// <summary>Stages, used when the definition produced more than one.</summary>
     public StageAzDO[] stages { get; set; }
+
+    /// <summary>Jobs, used when the definition produced a single stage with more than one job.</summary>
     public Job[] jobs { get; set; }
+
+    /// <summary>Steps, used when the definition produced a single job.</summary>
     public Step[] steps { get; set; }
+
+    /// <summary>Service containers available to the run.</summary>
     public Dictionary<string, string> services { get; set; }
 
+    /// <summary>Serialises this pipeline to Azure Pipelines YAML.</summary>
+    /// <remarks>
+    /// Unset properties are omitted, aliases are disabled so a repeated object is written out in full
+    /// rather than referenced, and <see cref="LiteralMultilineEventEmitter"/> keeps a multi-line
+    /// script readable as a literal block scalar. The final replacement restores the trailing newline
+    /// that the clip indicator would otherwise strip from such a block.
+    /// </remarks>
+    /// <returns>The YAML document.</returns>
     public override string ToString()
     {
         var serializer = new SerializerBuilder()

--- a/src/CasCap.Api.AzureDevOps/Models/Yaml/Pipeline.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/Yaml/Pipeline.cs
@@ -5,7 +5,7 @@ namespace CasCap.Models;
 public class Pipeline
 {
     public string name { get; set; }
-    public Dictionary<string, string> parameters { get; set; }
+    public List<TemplateParameter> parameters { get; set; }
     public string container { get; set; }
     public Resources resources { get; set; }
     public TriggerAzDO trigger { get; set; }

--- a/src/CasCap.Api.AzureDevOps/Models/Yaml/StageAzDO.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/Yaml/StageAzDO.cs
@@ -1,14 +1,35 @@
 ﻿namespace CasCap.Models;
 
-public class StageAzDO// : Stage //we can't inherit from Stage here as it will mess up the order of the properties when YAMLised.
+/// <summary>One stage of a generated Azure Pipelines YAML document.</summary>
+/// <remarks>
+/// Deliberately does not inherit from <c>Stage</c>. Inheriting reorders the properties when
+/// serialised, and the serialised order is the order they appear in the emitted YAML.
+/// </remarks>
+public class StageAzDO
 {
+    /// <summary>Stage identifier, which must match <c>[A-Za-z_][A-Za-z0-9_]*</c>.</summary>
     public string stage { get; set; }
+
+    /// <summary>Human readable stage name.</summary>
     public string displayName { get; set; }
+
+    /// <summary>Identifiers of the stages that must complete before this one starts.</summary>
     public string[] dependsOn { get; set; }
+
+    /// <summary>Expression deciding whether the stage runs.</summary>
     public string condition { get; set; }
-    //public Dictionary<string, string> variables { get; set; }
-    //override variables as we need the distinction between groups & templates
+
+    /// <summary>Stage-scoped variables, including linked variable groups.</summary>
+    /// <remarks>
+    /// A <see cref="List{T}"/> of <see cref="Variable"/> rather than a name and value dictionary,
+    /// because a stage may also reference a variable group or a variable template, which a dictionary
+    /// cannot express. Omitted entirely when empty.
+    /// </remarks>
     public List<Variable> variables { get; set; }
+
+    /// <summary>Agent pool the stage's jobs run on.</summary>
     public Pool pool { get; set; }
+
+    /// <summary>Jobs belonging to this stage.</summary>
     public Job[] jobs { get; set; }
 }

--- a/src/CasCap.Api.AzureDevOps/Models/Yaml/Template.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/Yaml/Template.cs
@@ -2,8 +2,15 @@
 
 namespace CasCap.Models;
 
+/// <summary>A step template generated from a classic task group.</summary>
+/// <remarks>
+/// One file is produced per task group version and referenced by every definition that uses it,
+/// unless <c>--inline</c> was passed, in which case the task group's steps are expanded in place.
+/// </remarks>
 public class Template : Pipeline
 {
+    /// <summary>The task group this template was generated from.</summary>
+    /// <remarks>Carried for the file name and version only, so it is never serialised.</remarks>
     [YamlIgnore]
     public TaskGroup taskGroup { get; set; }
 }

--- a/src/CasCap.Api.AzureDevOps/Models/Yaml/TemplateParameter.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/Yaml/TemplateParameter.cs
@@ -1,0 +1,19 @@
+namespace CasCap.Models;
+
+/// <summary>
+/// One entry in a template's <c>parameters</c> declaration.
+/// </summary>
+/// <remarks>
+/// A template that declares its parameters as a mapping is rejected by the Azure Pipelines schema,
+/// which expects a sequence of these. Callers still pass values as a mapping, which is why
+/// <see cref="Step.parameters"/> keeps that shape.
+/// </remarks>
+public class TemplateParameter
+{
+    public string name { get; set; }
+
+    /// <summary>Classic task group inputs carry no usable type, so every parameter is a string.</summary>
+    public string type { get; set; } = "string";
+
+    public string @default { get; set; }
+}

--- a/src/CasCap.Api.AzureDevOps/Models/Yaml/TemplateParameter.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/Yaml/TemplateParameter.cs
@@ -10,10 +10,13 @@ namespace CasCap.Models;
 /// </remarks>
 public class TemplateParameter
 {
+    /// <summary>Name callers supply a value under, and the name the template body references.</summary>
     public string name { get; set; }
 
     /// <summary>Classic task group inputs carry no usable type, so every parameter is a string.</summary>
     public string type { get; set; } = "string";
 
+    /// <summary>Value used when a caller supplies none.</summary>
+    /// <remarks>Taken from the task group input's default, and null when it declared none.</remarks>
     public string @default { get; set; }
 }

--- a/src/CasCap.Api.AzureDevOps/Models/Yaml/TriggerAzDO.cs
+++ b/src/CasCap.Api.AzureDevOps/Models/Yaml/TriggerAzDO.cs
@@ -1,8 +1,14 @@
 ﻿namespace CasCap.Models;
 
+/// <summary>A continuous integration or pull request trigger.</summary>
+/// <remarks>
+/// Exists to let the emitted property order be controlled independently of <see cref="Trigger"/>.
+/// <para>
+/// Hiding the inherited <c>batch</c> and <c>autoCancel</c> properties with <c>new</c> is not viable:
+/// the serialiser then throws <see cref="System.Reflection.AmbiguousMatchException"/> because two
+/// properties of the same name are visible on the type.
+/// </para>
+/// </remarks>
 public class TriggerAzDO : Trigger
 {
-    // comment out batch else get the error Unhandled exception. System.Reflection.AmbiguousMatchException: Ambiguous match found for 'CasCap.Models.TriggerAzDO Boolean batch'.
-    //public new bool batch { get; set; }
-    //public new bool autoCancel { get; set; }
 }

--- a/src/CasCap.Api.AzureDevOps/Services/ApiService.cs
+++ b/src/CasCap.Api.AzureDevOps/Services/ApiService.cs
@@ -1,31 +1,11 @@
-﻿using CasCap.Common.Services;
+﻿using CasCap.Abstractions;
+using CasCap.Common.Services;
 using CasCap.Models;
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Headers;
 using System.Text;
 
 namespace CasCap.Services;
-
-/// <summary>Azure DevOps REST calls that the official client libraries do not cover.</summary>
-public interface IApiService
-{
-    /// <summary>Retrieves every task installed in the organisation.</summary>
-    /// <remarks>
-    /// The classic definition names a task only by identifier and version spec, so this catalogue is
-    /// what resolves it to the <c>Name@Major</c> reference a YAML step needs.
-    /// </remarks>
-    /// <param name="organisationUri">Absolute organisation Uri, for example <c>https://dev.azure.com/myorg</c>.</param>
-    /// <returns>Every installed task, or null when the response carried none.</returns>
-    Task<List<TaskObj>> GetAllExtensions(string organisationUri);
-
-    /// <summary>Asks Azure DevOps to validate a YAML document without queueing a run.</summary>
-    /// <param name="organisation">Organisation name, the segment after <c>dev.azure.com/</c>.</param>
-    /// <param name="project">Team project name.</param>
-    /// <param name="pipelineId">Identifier of an existing YAML pipeline to preview against.</param>
-    /// <param name="pipelineYaml">The document to validate.</param>
-    /// <returns>The preview response body, or null when the call returned none.</returns>
-    Task<string> Validate(string organisation, string project, int pipelineId, string pipelineYaml);
-}
 
 /// <inheritdoc cref="IApiService"/>
 public class ApiService : HttpClientBase, IApiService

--- a/src/CasCap.Api.AzureDevOps/Services/ApiService.cs
+++ b/src/CasCap.Api.AzureDevOps/Services/ApiService.cs
@@ -6,14 +6,36 @@ using System.Text;
 
 namespace CasCap.Services;
 
+/// <summary>Azure DevOps REST calls that the official client libraries do not cover.</summary>
 public interface IApiService
 {
+    /// <summary>Retrieves every task installed in the organisation.</summary>
+    /// <remarks>
+    /// The classic definition names a task only by identifier and version spec, so this catalogue is
+    /// what resolves it to the <c>Name@Major</c> reference a YAML step needs.
+    /// </remarks>
+    /// <param name="organisationUri">Absolute organisation Uri, for example <c>https://dev.azure.com/myorg</c>.</param>
+    /// <returns>Every installed task, or null when the response carried none.</returns>
     Task<List<TaskObj>> GetAllExtensions(string organisationUri);
+
+    /// <summary>Asks Azure DevOps to validate a YAML document without queueing a run.</summary>
+    /// <param name="organisation">Organisation name, the segment after <c>dev.azure.com/</c>.</param>
+    /// <param name="project">Team project name.</param>
+    /// <param name="pipelineId">Identifier of an existing YAML pipeline to preview against.</param>
+    /// <param name="pipelineYaml">The document to validate.</param>
+    /// <returns>The preview response body, or null when the call returned none.</returns>
     Task<string> Validate(string organisation, string project, int pipelineId, string pipelineYaml);
 }
 
+/// <inheritdoc cref="IApiService"/>
 public class ApiService : HttpClientBase, IApiService
 {
+    /// <summary>Creates a client authenticated against Azure DevOps.</summary>
+    /// <param name="logger">Logger for diagnostics.</param>
+    /// <param name="PAT">
+    /// Personal Access Token, or an access token issued to a pipeline's build service identity.
+    /// Never validated by length, because the two differ; an invalid token surfaces as a failed call.
+    /// </param>
     public ApiService(ILogger<ApiService> logger, string PAT) : base()
     {
         _logger = logger;
@@ -24,6 +46,7 @@ public class ApiService : HttpClientBase, IApiService
         Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(bytes));
     }
 
+    /// <inheritdoc/>
     public async Task<List<TaskObj>> GetAllExtensions(string organisationUri)
     {
         _logger.LogInformation("{ClassName} retrieving all extensions for organisation '{OrganisationUri}'",
@@ -32,7 +55,10 @@ public class ApiService : HttpClientBase, IApiService
         return res.result is not null && res.result.value is not null ? res.result.value : null;
     }
 
-    //https://docs.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/run%20pipeline?view=azure-devops-rest-6.0
+    /// <inheritdoc/>
+    /// <remarks>
+    /// See <see href="https://docs.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/run%20pipeline?view=azure-devops-rest-6.0" />.
+    /// </remarks>
     public async Task<string> Validate(string organisation, string project, int pipelineId, string pipelineYaml)
     {
         _logger.LogInformation("{ClassName} validating YAML for project '{Project}' in organisation '{Organisation}'",

--- a/src/CasCap.Api.AzureDevOps/Services/ApiService.cs
+++ b/src/CasCap.Api.AzureDevOps/Services/ApiService.cs
@@ -1,4 +1,5 @@
 ﻿using CasCap.Abstractions;
+using CasCap.Common.Extensions;
 using CasCap.Common.Services;
 using CasCap.Models;
 using Microsoft.Extensions.Logging;
@@ -23,8 +24,7 @@ public class ApiService : HttpClientBase, IApiService
         Client = new HttpClient();
         Client.DefaultRequestHeaders.Clear();
         Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        var bytes = Encoding.ASCII.GetBytes($"{string.Empty}:{PAT}");
-        Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(bytes));
+        Client.SetBasicAuth(string.Empty, PAT);
     }
 
     /// <inheritdoc/>
@@ -33,7 +33,7 @@ public class ApiService : HttpClientBase, IApiService
         _logger.LogInformation("{ClassName} retrieving all extensions for organisation '{OrganisationUri}'",
             nameof(ApiService), organisationUri);
         var res = await Get<Tasks, object>($"{organisationUri}/_apis/distributedtask/tasks/");
-        return res.result is not null && res.result.value is not null ? res.result.value : null;
+        return res.result?.value;
     }
 
     /// <inheritdoc/>

--- a/src/CasCap.Api.AzureDevOps/Services/ApiService.cs
+++ b/src/CasCap.Api.AzureDevOps/Services/ApiService.cs
@@ -4,6 +4,7 @@ using CasCap.Models;
 using Microsoft.Extensions.Logging;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 
 namespace CasCap.Services;
 
@@ -36,22 +37,46 @@ public class ApiService : HttpClientBase, IApiService
     }
 
     /// <inheritdoc/>
-    /// <remarks>
-    /// See <see href="https://docs.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/run%20pipeline?view=azure-devops-rest-6.0" />.
-    /// </remarks>
-    public async Task<string> Validate(string organisation, string project, int pipelineId, string pipelineYaml)
+    public async Task<PipelineValidationResult> Validate(
+        string organisationUri,
+        string project,
+        int pipelineId,
+        string pipelineYaml,
+        CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("{ClassName} validating YAML for project '{Project}' in organisation '{Organisation}'",
-            nameof(ApiService), project, organisation);
-        var req = new
+        _logger.LogInformation("{ClassName} validating YAML against pipeline {PipelineId} in project '{Project}'",
+            nameof(ApiService), pipelineId, project);
+
+        var uri = $"{organisationUri.TrimEnd('/')}/{Uri.EscapeDataString(project)}/_apis/pipelines/{pipelineId}/preview?api-version=7.1";
+        var payload = JsonSerializer.Serialize(new { previewRun = true, yamlOverride = pipelineYaml });
+
+        using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+        using var response = await Client.PostAsync(uri, content, cancellationToken);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        if (response.IsSuccessStatusCode)
+            return new PipelineValidationResult { IsValid = true, FinalYaml = ReadProperty(body, "finalYaml") };
+
+        //the rejection reason is the whole point of the call, so fall back to the status when absent
+        var message = ReadProperty(body, "message") ?? $"Azure DevOps returned {(int)response.StatusCode}.";
+        _logger.LogWarning("{ClassName} rejected YAML for pipeline {PipelineId}, {Message}",
+            nameof(ApiService), pipelineId, message);
+
+        return new PipelineValidationResult { IsValid = false, Message = message };
+    }
+
+    private static string ReadProperty(string json, string name)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+
+        try
         {
-            previewRun = true,
-            yamlOverride = $@"
-# your YAML here
-{pipelineYaml}
-"
-        };
-        var res = await PostJsonAsync<string, object>($"https://dev.azure.com/{organisation}/{project}/_apis/pipelines/{pipelineId}/runs?api-version=6.0-preview.1", req);
-        return res.result is not null ? res.result : null;
+            using var document = JsonDocument.Parse(json);
+            return document.RootElement.TryGetProperty(name, out var value) ? value.GetString() : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 }

--- a/src/CasCap.Api.AzureDevOps/Utilities/LiteralMultilineEventEmitter.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/LiteralMultilineEventEmitter.cs
@@ -3,10 +3,19 @@ using YamlDotNet.Serialization.EventEmitters;
 
 namespace CasCap.Utilities;
 
+/// <summary>Emits any multi-line string as a literal block scalar.</summary>
+/// <remarks>
+/// Without this, YamlDotNet writes a multi-line inline script as a quoted scalar with escaped
+/// newlines, which is valid YAML but unreadable and impossible to edit by hand. Converted pipelines
+/// are expected to be reviewed, so readability matters.
+/// </remarks>
 public class LiteralMultilineEventEmitter : ChainedEventEmitter
 {
+    /// <summary>Wraps the next emitter in the chain.</summary>
+    /// <param name="nextEmitter">The emitter to delegate to once the style has been set.</param>
     public LiteralMultilineEventEmitter(IEventEmitter nextEmitter) : base(nextEmitter) { }
 
+    /// <inheritdoc/>
     public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter)
     {
         if (eventInfo.Source.Type == typeof(string) && eventInfo.Source.Value is string value && value.Contains("\n"))

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -127,11 +127,12 @@ public class YamlPipelineGenerator
         if (allPhases.Count > phases.Count)
             _warnings.Add($"{allPhases.Count - phases.Count} non-agent build phase(s) are not converted, see https://github.com/f2calv/yamlizr/issues/182");
         if (phases.IsNullOrEmpty()) return null;
-        var jobs = new List<Job>(phases.Count);
-        var jobName = string.Empty;
         //TODO(#368): inverted, this is true when the names DIFFER. Phases that all share one name get
         //no suffix and so produce duplicate job identifiers. https://github.com/f2calv/yamlizr/issues/368
         var duplicatePhaseNames = phases.Select(p => p.Name).Distinct().Count() > 1;
+
+        // Identifiers are assigned up front, because a phase may depend on one declared after it.
+        var converted = new List<(Phase phase, string jobId, List<Step> steps)>(phases.Count);
         var j = 0;
         foreach (var phase in phases)
         {
@@ -141,21 +142,32 @@ public class YamlPipelineGenerator
             if (steps.IsNullOrEmpty()) continue;
             //a classic phase can have no name, which used to throw from Sanitize().Replace()
             var phaseName = string.IsNullOrWhiteSpace(phase.Name) ? $"Phase {j + 1}" : phase.Name;
+            var identifier = ToIdentifier(phaseName, $"Phase_{j + 1}");
+            converted.Add((phase, duplicatePhaseNames ? $"{identifier}_{j}" : identifier, steps));
+            j++;
+        }
+        if (converted.IsNullOrEmpty()) return null;
+
+        var jobIdByRefName = new Dictionary<string, string>(converted.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var (phase, jobId, _) in converted)
+            if (!string.IsNullOrWhiteSpace(phase.RefName)) jobIdByRefName[phase.RefName] = jobId;
+
+        var jobs = new List<Job>(converted.Count);
+        foreach (var (phase, jobId, steps) in converted)
+        {
             var job = new Job
             {
                 cancelTimeoutInMinutes = phase.JobCancelTimeoutInMinutes,
                 condition = GenCondition(phase.Condition),
-                dependsOn = string.IsNullOrWhiteSpace(jobName) ? null : new[] { jobName },
-                displayName = phaseName,
-                job = duplicatePhaseNames ? $"{ToIdentifier(phaseName, $"Phase_{j + 1}")}_{j}" : ToIdentifier(phaseName, $"Phase_{j + 1}"),
+                dependsOn = GenDependsOn(phase, jobIdByRefName),
+                displayName = string.IsNullOrWhiteSpace(phase.Name) ? jobId : phase.Name,
+                job = jobId,
                 steps = steps.ToArray(),
                 timeoutInMinutes = phase.JobTimeoutInMinutes,
             };
             jobs.Add(job);
-            jobName = job.job;
-            j++;
         }
-        if (jobs.IsNullOrEmpty()) return null;
+
         var stageVariables = GenVariables(VariableType.Build);
         return new StageAzDO
         {
@@ -164,6 +176,32 @@ public class YamlPipelineGenerator
             variables = stageVariables.IsNullOrEmpty() ? null : stageVariables,
             jobs = jobs.ToArray(),
         };
+    }
+
+    /// <summary>
+    /// Maps a classic phase's declared dependencies onto the identifiers of the generated jobs.
+    /// </summary>
+    /// <remarks>
+    /// A classic phase names its dependencies explicitly by refName, and may name more than one. This
+    /// previously emitted the preceding job in iteration order instead, which serialised phases that
+    /// were meant to run in parallel and silently dropped every dependency of a fan-in but the last.
+    /// </remarks>
+    private string[] GenDependsOn(Phase phase, Dictionary<string, string> jobIdByRefName)
+    {
+        if (phase.Dependencies.IsNullOrEmpty()) return null;
+
+        var dependsOn = new List<string>(phase.Dependencies.Count);
+        foreach (var dependency in phase.Dependencies)
+        {
+            if (jobIdByRefName.TryGetValue(dependency.Scope ?? string.Empty, out var jobId))
+            {
+                if (!dependsOn.Contains(jobId)) dependsOn.Add(jobId);
+            }
+            else
+                _warnings.Add($"phase '{phase.Name}' depends on '{dependency.Scope}', which was not converted, so the dependency is missing from the generated YAML");
+        }
+
+        return dependsOn.Count == 0 ? null : dependsOn.ToArray();
     }
 
     TriggerAzDO GenTrigger()

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -337,8 +337,17 @@ public class YamlPipelineGenerator
     {
         if (string.IsNullOrWhiteSpace(name)) return fallback;
 
-        //DELIBERATE REGRESSION, see issue #366. Revert once CI has demonstrated the gate.
-        return name.Sanitize().Replace(" ", "_");
+        var builder = new StringBuilder(name.Length);
+        foreach (var c in name)
+            builder.Append(char.IsAsciiLetterOrDigit(c) || c == '_' ? c : '_');
+
+        // Collapse runs so "Phase three, fan-in" does not become Phase_three__fan_in.
+        var identifier = Regex.Replace(builder.ToString(), "_{2,}", "_").Trim('_');
+
+        if (identifier.Length == 0) return fallback;
+
+        // An identifier may not start with a digit.
+        return char.IsAsciiDigit(identifier[0]) ? $"_{identifier}" : identifier;
     }
 
     StageAzDO[] GenReleaseStages()

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -339,14 +339,19 @@ public class YamlPipelineGenerator
 
         var builder = new StringBuilder(name.Length);
         foreach (var c in name)
-            builder.Append(char.IsAsciiLetterOrDigit(c) || c == '_' ? c : '_');
+        {
+            var mapped = char.IsAsciiLetterOrDigit(c) || c == '_' ? c : '_';
+            //collapse runs, and drop leading ones, so "Phase three, fan-in" does not become Phase_three__fan_in
+            if (mapped == '_' && (builder.Length == 0 || builder[^1] == '_')) continue;
+            builder.Append(mapped);
+        }
 
-        // Collapse runs so "Phase three, fan-in" does not become Phase_three__fan_in.
-        var identifier = Regex.Replace(builder.ToString(), "_{2,}", "_").Trim('_');
+        while (builder.Length > 0 && builder[^1] == '_') builder.Length--;
 
-        if (identifier.Length == 0) return fallback;
+        if (builder.Length == 0) return fallback;
 
         // An identifier may not start with a digit.
+        var identifier = builder.ToString();
         return char.IsAsciiDigit(identifier[0]) ? $"_{identifier}" : identifier;
     }
 

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -420,18 +420,25 @@ public class YamlPipelineGenerator
                 if (!_taskGroupMap.TryGetValue(key, out var taskGroup))
                     return null;
                 template = new Template { taskGroup = taskGroup };
+                // Declared as a sequence for the schema, but substitution below needs a lookup.
+                Dictionary<string, string> parameterDefaults = null;
                 if (!taskGroup.Inputs.IsNullOrEmpty())
                 {
-                    template.parameters = new Dictionary<string, string>(taskGroup.Inputs.Count);
+                    template.parameters = new List<TemplateParameter>(taskGroup.Inputs.Count);
+                    parameterDefaults = new Dictionary<string, string>(taskGroup.Inputs.Count);
                     foreach (var input in taskGroup.Inputs)
-                        template.parameters.Add(input.Name, string.IsNullOrWhiteSpace(input.DefaultValue) ? null : input.DefaultValue);
+                    {
+                        var defaultValue = string.IsNullOrWhiteSpace(input.DefaultValue) ? null : input.DefaultValue;
+                        template.parameters.Add(new TemplateParameter { name = input.Name, @default = defaultValue });
+                        parameterDefaults[input.Name] = defaultValue;
+                    }
                 }
                 var taskGroupSteps = taskGroup.Tasks.Where(p => p.Enabled).ToList();
                 if (!taskGroupSteps.IsNullOrEmpty())
                 {
                     var steps = new List<Step>(taskGroupSteps.Count);
                     foreach (var taskGroupStep in taskGroupSteps)
-                        steps.AddRange(GenSteps(taskGroupStep, template.parameters));
+                        steps.AddRange(GenSteps(taskGroupStep, parameterDefaults));
                     template.steps = steps.ToArray();
                 }
                 template.steps ??= Array.Empty<Step>();//handle when all tasks within taskgroup are disabled

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -11,6 +11,16 @@ using System.Text.RegularExpressions;
 
 namespace CasCap.Utilities;
 
+/// <summary>Converts one classic Build or Release definition into an Azure Pipelines YAML document.</summary>
+/// <remarks>
+/// An instance handles a single definition, and <see cref="Warnings"/> is only complete once
+/// <see cref="GenPipeline"/> has returned.
+/// <para>
+/// The conversion is deliberately incomplete: several classic constructs have no YAML equivalent.
+/// Anything that cannot be represented is recorded in <see cref="Warnings"/> rather than dropped
+/// silently, so the caller can report it.
+/// </para>
+/// </remarks>
 public class YamlPipelineGenerator
 {
     private readonly BuildDefinition _build;
@@ -38,6 +48,19 @@ public class YamlPipelineGenerator
         Release
     }
 
+    /// <summary>Creates a generator for a single definition.</summary>
+    /// <remarks>Exactly one of <paramref name="build"/> and <paramref name="release"/> must be supplied.</remarks>
+    /// <param name="build">The classic Build definition to convert, or null when converting a release.</param>
+    /// <param name="release">The classic Release definition to convert, or null when converting a build.</param>
+    /// <param name="taskMap">Installed tasks, keyed by task identifier then major version.</param>
+    /// <param name="taskGroupMap">Task groups, keyed by identifier and version.</param>
+    /// <param name="taskGroupTemplateMap">
+    /// Templates generated so far, shared across every definition in the run and appended to as task
+    /// groups are encountered, which is why it is concurrent.
+    /// </param>
+    /// <param name="variableGroupMap">Variable groups, keyed by identifier.</param>
+    /// <param name="inlineTaskGroups">True to expand task group steps in place instead of emitting a template reference.</param>
+    /// <param name="phaseType">The single deploy phase type to convert; other phases are reported and skipped.</param>
     public YamlPipelineGenerator(
         BuildDefinition build,
         ReleaseDefinition release,
@@ -59,6 +82,15 @@ public class YamlPipelineGenerator
         _phaseType = phaseType;
     }
 
+    /// <summary>Converts the definition supplied to the constructor.</summary>
+    /// <remarks>
+    /// The result is flattened to the simplest shape that fits, because the schema rejects a document
+    /// mixing them: several stages become <see cref="Pipeline.stages"/>, a single stage with several
+    /// jobs becomes <see cref="Pipeline.jobs"/>, and a single job becomes <see cref="Pipeline.steps"/>.
+    /// Flattening discards settings that only a stage or a job can carry, which is reported.
+    /// </remarks>
+    /// <returns>The generated pipeline, or null when the definition produced nothing convertible.</returns>
+    /// <exception cref="GenericException">Thrown when neither or both of a build and a release were supplied.</exception>
     public Pipeline GenPipeline()
     {
         var pipeline = new Pipeline();

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -71,7 +71,8 @@ public class YamlPipelineGenerator
             pipeline.trigger = GenTrigger();
             if (_build.Queue is not null)
                 pipeline.pool = new Pool { name = _build.Queue.Name };
-            pipeline.variables = GenVariables(VariableType.Build);
+            var buildVariables = GenVariables(VariableType.Build);
+            pipeline.variables = buildVariables.IsNullOrEmpty() ? null : buildVariables;
             var buildStage = GenBuildStage();
             if (buildStage is not null)
                 if (buildStage.jobs.Length == 1)
@@ -88,8 +89,8 @@ public class YamlPipelineGenerator
         }
         else if (_build is null && _release is not null)//create release pipeline
         {
-            pipeline.variables = GenVariables(VariableType.Release);
-            if (pipeline.variables.Count == 0) pipeline.variables = null;
+            var releaseVariables = GenVariables(VariableType.Release);
+            pipeline.variables = releaseVariables.IsNullOrEmpty() ? null : releaseVariables;
             var releaseStages = GenReleaseStages();
             if (releaseStages is not null)
             {
@@ -154,7 +155,15 @@ public class YamlPipelineGenerator
             jobName = job.job;
             j++;
         }
-        return jobs.IsNullOrEmpty() ? null : new StageAzDO { displayName = _build.Name, stage = (_build.Name ?? "Build").Sanitize().Replace(" ", "_"), variables = GenVariables(VariableType.Build), jobs = jobs.ToArray() };
+        if (jobs.IsNullOrEmpty()) return null;
+        var stageVariables = GenVariables(VariableType.Build);
+        return new StageAzDO
+        {
+            displayName = _build.Name,
+            stage = (_build.Name ?? "Build").Sanitize().Replace(" ", "_"),
+            variables = stageVariables.IsNullOrEmpty() ? null : stageVariables,
+            jobs = jobs.ToArray(),
+        };
     }
 
     TriggerAzDO GenTrigger()

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -147,7 +147,7 @@ public class YamlPipelineGenerator
                 condition = GenCondition(phase.Condition),
                 dependsOn = string.IsNullOrWhiteSpace(jobName) ? null : new[] { jobName },
                 displayName = phaseName,
-                job = duplicatePhaseNames ? $"{phaseName.Sanitize().Replace(" ", "_")}_{j}" : phaseName.Sanitize().Replace(" ", "_"),
+                job = duplicatePhaseNames ? $"{ToIdentifier(phaseName, $"Phase_{j + 1}")}_{j}" : ToIdentifier(phaseName, $"Phase_{j + 1}"),
                 steps = steps.ToArray(),
                 timeoutInMinutes = phase.JobTimeoutInMinutes,
             };
@@ -160,7 +160,7 @@ public class YamlPipelineGenerator
         return new StageAzDO
         {
             displayName = _build.Name,
-            stage = (_build.Name ?? "Build").Sanitize().Replace(" ", "_"),
+            stage = ToIdentifier(_build.Name, "Build"),
             variables = stageVariables.IsNullOrEmpty() ? null : stageVariables,
             jobs = jobs.ToArray(),
         };
@@ -254,6 +254,32 @@ public class YamlPipelineGenerator
 
     private static string GenCondition(string condition) => string.IsNullOrWhiteSpace(condition) || condition.Equals("succeeded()", StringComparison.OrdinalIgnoreCase) ? "succeeded()" : condition;
 
+    /// <summary>
+    /// Converts a classic phase or environment name into a YAML job or stage identifier.
+    /// </summary>
+    /// <remarks>
+    /// Azure DevOps accepts almost anything as a classic phase name, but a YAML identifier must match
+    /// <c>[A-Za-z_][A-Za-z0-9_]*</c>. Sanitize() is not enough on its own: it only strips characters
+    /// that are illegal in a file name, so a comma or a full stop survives into the identifier and the
+    /// pipeline is rejected on upload.
+    /// </remarks>
+    internal static string ToIdentifier(string name, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return fallback;
+
+        var builder = new StringBuilder(name.Length);
+        foreach (var c in name)
+            builder.Append(char.IsAsciiLetterOrDigit(c) || c == '_' ? c : '_');
+
+        // Collapse runs so "Phase three, fan-in" does not become Phase_three__fan_in.
+        var identifier = Regex.Replace(builder.ToString(), "_{2,}", "_").Trim('_');
+
+        if (identifier.Length == 0) return fallback;
+
+        // An identifier may not start with a digit.
+        return char.IsAsciiDigit(identifier[0]) ? $"_{identifier}" : identifier;
+    }
+
     StageAzDO[] GenReleaseStages()
     {
         if (_release.Environments.IsNullOrEmpty()) return null;
@@ -284,7 +310,7 @@ public class YamlPipelineGenerator
             {
                 displayName = _release.Name,
                 jobs = jobs.ToArray(),
-                stage = (environment.Name ?? $"Stage_{stages.Count + 1}").Sanitize("_"),
+                stage = ToIdentifier(environment.Name, $"Stage_{stages.Count + 1}"),
                 variables = variables.IsNullOrEmpty() ? null : variables,
             };
             stages.Add(stage);
@@ -329,7 +355,7 @@ public class YamlPipelineGenerator
                     condition = GenCondition(deploymentInput.Condition),
                     dependsOn = string.IsNullOrWhiteSpace(jobName) ? null : new[] { jobName },
                     displayName = phaseName,
-                    job = duplicatePhaseNames ? $"{phaseName.Sanitize().Replace(" ", "_")}_{j}" : phaseName.Sanitize().Replace(" ", "_"),
+                    job = duplicatePhaseNames ? $"{ToIdentifier(phaseName, $"Phase_{j + 1}")}_{j}" : ToIdentifier(phaseName, $"Phase_{j + 1}"),
                     steps = new List<Step>(steps).ToArray(),
                     timeoutInMinutes = deploymentInput.TimeoutInMinutes,
                 };

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -376,11 +376,13 @@ public class YamlPipelineGenerator
             //artifact and environment dependencies, which should become stage dependsOn/condition.
             //https://github.com/f2calv/yamlizr/issues/182
             var variables = GenVariables(VariableType.Release, environment);
+            var stageName = ToIdentifier(environment.Name, $"Stage_{stages.Count + 1}");
             var stage = new StageAzDO
             {
-                displayName = _release.Name,
+                // The release definition names the document, not each stage within it.
+                displayName = string.IsNullOrWhiteSpace(environment.Name) ? stageName : environment.Name,
                 jobs = jobs.ToArray(),
-                stage = ToIdentifier(environment.Name, $"Stage_{stages.Count + 1}"),
+                stage = stageName,
                 variables = variables.IsNullOrEmpty() ? null : variables,
             };
             stages.Add(stage);

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -337,17 +337,8 @@ public class YamlPipelineGenerator
     {
         if (string.IsNullOrWhiteSpace(name)) return fallback;
 
-        var builder = new StringBuilder(name.Length);
-        foreach (var c in name)
-            builder.Append(char.IsAsciiLetterOrDigit(c) || c == '_' ? c : '_');
-
-        // Collapse runs so "Phase three, fan-in" does not become Phase_three__fan_in.
-        var identifier = Regex.Replace(builder.ToString(), "_{2,}", "_").Trim('_');
-
-        if (identifier.Length == 0) return fallback;
-
-        // An identifier may not start with a digit.
-        return char.IsAsciiDigit(identifier[0]) ? $"_{identifier}" : identifier;
+        //DELIBERATE REGRESSION, see issue #366. Revert once CI has demonstrated the gate.
+        return name.Sanitize().Replace(" ", "_");
     }
 
     StageAzDO[] GenReleaseStages()

--- a/src/CasCap.DevOpsYamlizrCli/CasCap.DevOpsYamlizrCli.csproj
+++ b/src/CasCap.DevOpsYamlizrCli/CasCap.DevOpsYamlizrCli.csproj
@@ -20,12 +20,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Figgle" />
     <PackageReference Include="Figgle.Fonts" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" />
     <PackageReference Include="McMaster.Extensions.Hosting.CommandLine" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <PackageReference Include="ShellProgressBar" />
   </ItemGroup>

--- a/src/CasCap.DevOpsYamlizrCli/Commands/CommandBase.cs
+++ b/src/CasCap.DevOpsYamlizrCli/Commands/CommandBase.cs
@@ -11,19 +11,30 @@ using System.Collections.Concurrent;
 
 namespace CasCap.Commands;
 
-/// <summary>
-/// This base type provides shared functionality.
-/// Also, declaring <see cref="HelpOptionAttribute"/> on this type means all types that inherit from it
-/// will automatically support '--help'
-/// </summary>
+/// <summary>Shared state and Azure DevOps clients for every yamlizr command.</summary>
+/// <remarks>
+/// Declaring <see cref="HelpOptionAttribute"/> here gives every inheriting command <c>--help</c>
+/// without repeating the attribute.
+/// </remarks>
 [HelpOption("--help")]
 public abstract class CommandBase
 {
+    /// <summary>Logger for diagnostics.</summary>
     protected /*readonly*/ ILogger _logger;
+
+    /// <summary>Factory used to create loggers for types constructed after the command starts.</summary>
     protected /*readonly*/ ILoggerFactory _loggerFactory;
+
+    /// <summary>Console this command writes its user interface to.</summary>
     protected /*readonly*/ IConsole _console;
+
+    /// <summary>Azure DevOps REST calls the official client libraries do not cover.</summary>
     protected /*readonly*/ IApiService _apiSvc;
 
+    /// <summary>Initialises the shared dependencies.</summary>
+    /// <param name="logger">Logger for diagnostics.</param>
+    /// <param name="loggerFactory">Factory for loggers created later in the run.</param>
+    /// <param name="console">Console to write progress and results to.</param>
     protected CommandBase(ILogger<CommandBase> logger, ILoggerFactory loggerFactory, IConsole console)
     {
         _logger = logger;
@@ -31,21 +42,41 @@ public abstract class CommandBase
         _console = console;
     }
 
+    /// <summary>Client for team project metadata.</summary>
     protected ProjectHttpClient _projectClient;
+
+    /// <summary>Client for classic Build definitions.</summary>
     protected BuildHttpClient _buildClient;
+
+    /// <summary>Client for classic Release definitions.</summary>
     protected ReleaseHttpClient _releaseClient;
+
+    /// <summary>Client for task groups and variable groups.</summary>
     protected TaskAgentHttpClient _taskAgentClient;
 
+    /// <summary>Credential built from the supplied access token.</summary>
     protected VssBasicCredential _credentials;
+
+    /// <summary>Connection every client above is created from.</summary>
     protected VssConnection _connection;
 
+    /// <summary>The team project being converted.</summary>
     protected TeamProject _project;
+
+    /// <summary>Build definition references, which carry a name and identifier but no process.</summary>
     protected List<BuildDefinitionReference> buildDefinitionReferences;
-    //appended-to from parallel loops, so it must be a concurrent collection
+
+    /// <summary>Fully loaded build definitions.</summary>
+    /// <remarks>Appended to from parallel loops, so it must be a concurrent collection.</remarks>
     protected ConcurrentBag<BuildDefinition> buildDefinitions;
+
+    /// <summary>Fully loaded release definitions.</summary>
     protected List<ReleaseDefinition> releaseDefinitions;
 
+    /// <summary>Progress bar for the current top-level operation.</summary>
     protected ProgressBar pbar;
+
+    /// <summary>Appearance of <see cref="pbar"/>.</summary>
     protected ProgressBarOptions pbarOptions { get; set; } = new ProgressBarOptions
     {
         ProgressCharacter = '─',
@@ -57,7 +88,10 @@ public abstract class CommandBase
         ShowEstimatedDuration = true,
     };
 
+    /// <summary>Progress bar nested inside <see cref="pbar"/>.</summary>
     protected ChildProgressBar childPBar;
+
+    /// <summary>Appearance of <see cref="childPBar"/>.</summary>
     protected ProgressBarOptions childPbarOptions { get; set; } = new ProgressBarOptions
     {
         ProgressCharacter = '─',
@@ -69,6 +103,10 @@ public abstract class CommandBase
         CollapseWhenFinished = true,
     };
 
+    /// <summary>Resolves the named team project and stores it in <see cref="_project"/>.</summary>
+    /// <param name="project">Team project name.</param>
+    /// <param name="cancellationToken">Token to cancel the lookup.</param>
+    /// <returns>True when the project was found, otherwise false.</returns>
     protected async Task<bool> GetProjectAsync(string project, CancellationToken cancellationToken = default)
     {
         _console.Write($"Retrieving Azure DevOps Project '{project}' ... ");

--- a/src/CasCap.DevOpsYamlizrCli/Commands/CommandBase.cs
+++ b/src/CasCap.DevOpsYamlizrCli/Commands/CommandBase.cs
@@ -1,4 +1,5 @@
-﻿using CasCap.Services;
+﻿using CasCap.Abstractions;
+using CasCap.Services;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.Core.WebApi;
 using Microsoft.TeamFoundation.DistributedTask.WebApi;


### PR DESCRIPTION
Closes #366.

Adds an end-to-end conversion gate: every classic fixture definition is converted and the resulting YAML is submitted to the Azure DevOps pipeline preview endpoint, so CI fails if yamlizr emits YAML that Azure DevOps will not accept. Building the fixtures surfaced five real generator bugs, each fixed in its own commit.

## Why preview rather than snapshots

The issue asked for snapshot tests. Snapshots only prove the output has not *changed*, and they pass the moment someone regenerates them, so all five bugs below would have survived a snapshot suite. Asking the server to parse the YAML proves it is *valid*.

## Generator bugs found and fixed

| Commit | Bug |
| --- | --- |
| `35ff2ec` | `variables: []` emitted when a definition has none |
| `eebb871` | Job names kept characters that are illegal in a YAML identifier, so a phase named `Phase three, fan-in` produced YAML Azure DevOps rejects |
| `9e3e8eb` | Template `parameters` serialised as a mapping instead of a sequence |
| `e43ec26` | `dependsOn` was fabricated as a linear chain, silently discarding the declared phase dependencies |
| `9aec91b` | Every release stage was named after the definition rather than its environment |

`e43ec26` is the one worth a reviewer's attention: it was silent data loss rather than a malformed document, so the generated pipeline ran in the wrong order without any warning.

## What else is here

- `.scripts/New-FixtureDefinitions.ps1` builds the classic fixtures (multi-phase, server phase, multiline scripts, task groups, triggers and variables, multi-stage release) plus the YAML pipeline the preview endpoint parses against. All fixtures share a name prefix so a run can filter to them, which exercises `--filter` as a side effect.
- Integration tests now run in CI before the pack and push, so a regression blocks publishing. They skip rather than fail when no credential is present, so forks stay green.
- An Azure DevOps MCP server whose token is read from a git-ignored `.env`.
- Editor schema validation for generated YAML, container build scripts and a Debug image, XML documentation across the public API, and `IApiService` moved into an `Abstractions` namespace.

## Related issues, none of which this closes

- **#182 (List of Missing Features)** — not addressed. `e43ec26` fixes `dependsOn` between *jobs in a build pipeline*, which is a different construct from the *stage inter-dependencies* listed in #182. Release stages are still emitted without `dependsOn` and still raise the run-summary warning that points at #182. Artifacts and pre-deployment approvals are likewise untouched.
- **#368 (Duplicate phase names)** — not fixed. `eebb871` changes the same code path, making job names valid YAML identifiers, but a definition whose phases all share one name still produces colliding identifiers. No fixture covers this case, so the new CI gate will not catch it either.
- **#365 (Enable nullable reference types)** and **#364 (Remove .NET 8 and .NET 9 targets)** — untouched.

## Repository configuration required

The `build` job reads these. Without them the integration tests skip and the gate is inert.

| Kind | Name |
| --- | --- |
| Secret | `AZURE_DEVOPS_PAT` |
| Variable | `AZURE_DEVOPS_ORGANISATION_URI` |
| Variable | `AZURE_DEVOPS_PROJECT` |
| Variable | `AZURE_DEVOPS_VALIDATION_PIPELINE_ID` |

The token needs read scopes plus Build read and execute for the preview endpoint. Nothing in the suite writes to the organisation, and a preview run parses without queueing.

## Verification

The gate was proven by deliberately reverting one of the fixes and pushing it, in `20d0d25`. The unit suite passed, the preview tests failed naming the definition and quoting the Azure DevOps error, and no package was published. Restored in `0f6e239`. Both commits are kept so the demonstration stays on the record.
