### PR TITLE
Guarantee unique job identifiers rather than predicting collisions

### DIFF
--- a/.github/instructions/csharp.testing.instructions.md
+++ b/.github/instructions/csharp.testing.instructions.md
@@ -47,6 +47,16 @@ Tests/
 - Consolidate facts that differ only by input into one `[Theory]` with `[InlineData]`.
 - Keep `[Fact]` for tests whose setup or assertions do not parameterize cleanly.
 
+## Duplication
+
+Test code is held to the same duplication gate as production code. SonarCloud fails a pull request
+above 3% duplication on new code, and copy-pasted arrange blocks are the usual cause.
+
+- When two tests differ only by input, use a `[Theory]`. When they differ only by fixture or by the assertion, extract a private helper on the test class that takes the varying values as parameters.
+- Build a new fixture from an existing one rather than restating it. A fixture that varies a single dimension should delegate to a shared private builder in the same `*TestData.cs`, not repeat the object graph.
+- Extract a repeated arrange block once it appears in a third test, or as soon as it exceeds a handful of lines in a second.
+- Keep the intent readable after extracting. A helper named for what it asserts, such as `AssertGeneratedYamlIsAccepted`, is preferable to one named for its mechanics.
+
 ## Test Method Naming
 
 - Name test methods after the method or feature under test, such as `GenPipeline` or `SanitizesDefinitionName`.

--- a/README.md
+++ b/README.md
@@ -300,7 +300,6 @@ without a trace. Progress on closing these gaps is tracked in
 | Triggers other than continuous integration (pull request, scheduled, build completion) | Not converted. |
 | Steps referencing an uninstalled extension | Not converted; reported by name and task id. |
 | Stage or job settings on a single-stage or single-job definition | A lone stage or job is flattened into a bare step list, dropping stage-level variables and a non-default job condition. |
-| Phases that all share one name | Generated job identifiers collide, producing YAML that will not validate, see [issue #368](https://github.com/f2calv/yamlizr/issues/368). |
 | Combined build plus release multi-stage pipelines | Build and release definitions are emitted as separate files. |
 
 ## Known Issues

--- a/src/CasCap.Api.AzureDevOps.Tests/README.md
+++ b/src/CasCap.Api.AzureDevOps.Tests/README.md
@@ -21,9 +21,9 @@ Tests/
 
 | Suite | Test methods | Expanded cases |
 | --- | --- | --- |
-| Unit | 12 | 18 |
-| Integration | 7 | 7 |
-| **Total** | **19** | **25** |
+| Unit | 18 | 27 |
+| Integration | 8 | 8 |
+| **Total** | **26** | **35** |
 
 ## Trait Categories
 

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/PipelineValidationTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/PipelineValidationTests.cs
@@ -143,6 +143,29 @@ public class PipelineValidationTests : TestBase
         Assert.True(result.IsValid, $"{result.Message}{Environment.NewLine}{yaml}");
     }
 
+    //https://github.com/f2calv/yamlizr/issues/368
+    [Fact]
+    public async Task GeneratedYaml_ForPhasesSharingOneName_IsAccepted()
+    {
+        Assert.SkipUnless(CanValidate, NoValidationPipeline);
+
+        var taskMap = YamlizrTestData.TaskMap("CmdLine", 2, "script");
+        var step = YamlizrTestData.Step(
+            YamlizrTestData.KnownTaskId,
+            versionSpec: "2.*",
+            inputs: new Dictionary<string, string> { ["script"] = "echo hello" });
+
+        var definition = YamlizrTestData.BuildDefinitionWithPhases(
+            "Azure Pipelines", step, "Agent job", "Agent job", "Agent job");
+
+        var pipeline = YamlizrTestData.Generator(definition, taskMap).GenPipeline();
+        var yaml = pipeline.ToString();
+
+        var result = await Validate(yaml);
+
+        Assert.True(result.IsValid, $"{result.Message}{Environment.NewLine}{yaml}");
+    }
+
     private Task<PipelineValidationResult> Validate(string yaml)
         => _apiSvc.Validate(Options.OrganisationUri, Options.Project, Options.ValidationPipelineId.Value, yaml, TestContext.Current.CancellationToken);
 }

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/PipelineValidationTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Integration/PipelineValidationTests.cs
@@ -125,22 +125,7 @@ public class PipelineValidationTests : TestBase
     {
         Assert.SkipUnless(CanValidate, NoValidationPipeline);
 
-        //CmdLine really exists, because Azure DevOps rejects a reference to a task it cannot resolve
-        var taskMap = YamlizrTestData.TaskMap("CmdLine", 2, "script");
-        var step = YamlizrTestData.Step(
-            YamlizrTestData.KnownTaskId,
-            versionSpec: "2.*",
-            inputs: new Dictionary<string, string> { ["script"] = "echo hello" });
-
-        var definition = YamlizrTestData.BuildDefinitionWithPhases(
-            "Azure Pipelines", step, "Phase one", "Phase two", "Phase three, fan-in");
-
-        var pipeline = YamlizrTestData.Generator(definition, taskMap).GenPipeline();
-        var yaml = pipeline.ToString();
-
-        var result = await Validate(yaml);
-
-        Assert.True(result.IsValid, $"{result.Message}{Environment.NewLine}{yaml}");
+        await AssertGeneratedYamlIsAccepted("Phase one", "Phase two", "Phase three, fan-in");
     }
 
     //https://github.com/f2calv/yamlizr/issues/368
@@ -149,17 +134,20 @@ public class PipelineValidationTests : TestBase
     {
         Assert.SkipUnless(CanValidate, NoValidationPipeline);
 
+        await AssertGeneratedYamlIsAccepted("Agent job", "Agent job", "Agent job");
+    }
+
+    private async Task AssertGeneratedYamlIsAccepted(params string[] phaseNames)
+    {
+        //CmdLine really exists, because Azure DevOps rejects a reference to a task it cannot resolve
         var taskMap = YamlizrTestData.TaskMap("CmdLine", 2, "script");
         var step = YamlizrTestData.Step(
             YamlizrTestData.KnownTaskId,
             versionSpec: "2.*",
             inputs: new Dictionary<string, string> { ["script"] = "echo hello" });
 
-        var definition = YamlizrTestData.BuildDefinitionWithPhases(
-            "Azure Pipelines", step, "Agent job", "Agent job", "Agent job");
-
-        var pipeline = YamlizrTestData.Generator(definition, taskMap).GenPipeline();
-        var yaml = pipeline.ToString();
+        var definition = YamlizrTestData.BuildDefinitionWithPhases("Azure Pipelines", step, phaseNames);
+        var yaml = YamlizrTestData.Generator(definition, taskMap).GenPipeline().ToString();
 
         var result = await Validate(yaml);
 

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Unit/YamlPipelineGeneratorTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Unit/YamlPipelineGeneratorTests.cs
@@ -146,10 +146,7 @@ public class YamlPipelineGeneratorTests
     [InlineData("1st phase")]
     public void GenPipeline_PhaseNameNeedingSanitising_ProducesAValidJobIdentifier(string phaseName)
     {
-        var definition = YamlizrTestData.BuildDefinitionWithPhases(
-            "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), "Phase one", phaseName);
-
-        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+        var pipeline = GenerateWithPhases("Phase one", phaseName);
 
         Assert.NotNull(pipeline.jobs);
         //asserts the contract rather than exact names, which the sanitising cases below already cover
@@ -160,10 +157,7 @@ public class YamlPipelineGeneratorTests
     [Fact]
     public void GenPipeline_DistinctPhaseNames_AreNotSuffixed()
     {
-        var definition = YamlizrTestData.BuildDefinitionWithPhases(
-            "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), "Alpha", "Beta");
-
-        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+        var pipeline = GenerateWithPhases("Alpha", "Beta");
 
         Assert.Equal(["Alpha", "Beta"], pipeline.jobs.Select(p => p.job));
     }
@@ -172,10 +166,7 @@ public class YamlPipelineGeneratorTests
     public void GenPipeline_PhasesSharingOneName_ProduceUniqueJobIdentifiers()
     {
         //a classic definition names every phase "Agent job" until someone renames them
-        var definition = YamlizrTestData.BuildDefinitionWithPhases(
-            "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), "Agent job", "Agent job", "Agent job");
-
-        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+        var pipeline = GenerateWithPhases("Agent job", "Agent job", "Agent job");
 
         Assert.Equal(["Agent_job", "Agent_job_1", "Agent_job_2"], pipeline.jobs.Select(p => p.job));
         //dependsOn has to name the identifier actually emitted, not the shared phase name
@@ -187,10 +178,7 @@ public class YamlPipelineGeneratorTests
     [Fact]
     public void GenPipeline_PhaseNamesCollidingOnlyAfterSanitising_ProduceUniqueJobIdentifiers()
     {
-        var definition = YamlizrTestData.BuildDefinitionWithPhases(
-            "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), "Build (x86)", "Build [x86]");
-
-        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+        var pipeline = GenerateWithPhases("Build (x86)", "Build [x86]");
 
         Assert.Equal(["Build_x86", "Build_x86_1"], pipeline.jobs.Select(p => p.job));
     }
@@ -198,13 +186,16 @@ public class YamlPipelineGeneratorTests
     [Fact]
     public void GenPipeline_UnnamedPhases_AreGivenUniqueGeneratedNames()
     {
-        var definition = YamlizrTestData.BuildDefinitionWithPhases(
-            "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), "   ", null);
-
-        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+        var pipeline = GenerateWithPhases("   ", null);
 
         Assert.Equal(["Phase_1", "Phase_2"], pipeline.jobs.Select(p => p.job));
     }
+
+    private static Pipeline GenerateWithPhases(params string[] phaseNames)
+        => YamlizrTestData.Generator(
+            YamlizrTestData.BuildDefinitionWithPhases(
+                "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), phaseNames))
+            .GenPipeline();
 
     [Fact]
     public void GenPipeline_DeployPhasesSharingOneName_ProduceUniqueJobIdentifiers()

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Unit/YamlPipelineGeneratorTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Unit/YamlPipelineGeneratorTests.cs
@@ -152,8 +152,69 @@ public class YamlPipelineGeneratorTests
         var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
 
         Assert.NotNull(pipeline.jobs);
-        //asserts the contract rather than an exact name, which also carries the issue #368 index suffix
+        //asserts the contract rather than exact names, which the sanitising cases below already cover
         Assert.All(pipeline.jobs, p => Assert.Matches("^[A-Za-z_][A-Za-z0-9_]*$", p.job));
+    }
+
+    //https://github.com/f2calv/yamlizr/issues/368
+    [Fact]
+    public void GenPipeline_DistinctPhaseNames_AreNotSuffixed()
+    {
+        var definition = YamlizrTestData.BuildDefinitionWithPhases(
+            "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), "Alpha", "Beta");
+
+        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+
+        Assert.Equal(["Alpha", "Beta"], pipeline.jobs.Select(p => p.job));
+    }
+
+    [Fact]
+    public void GenPipeline_PhasesSharingOneName_ProduceUniqueJobIdentifiers()
+    {
+        //a classic definition names every phase "Agent job" until someone renames them
+        var definition = YamlizrTestData.BuildDefinitionWithPhases(
+            "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), "Agent job", "Agent job", "Agent job");
+
+        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+
+        Assert.Equal(["Agent_job", "Agent_job_1", "Agent_job_2"], pipeline.jobs.Select(p => p.job));
+        //dependsOn has to name the identifier actually emitted, not the shared phase name
+        Assert.Null(pipeline.jobs[0].dependsOn);
+        Assert.Equal(["Agent_job"], pipeline.jobs[1].dependsOn);
+        Assert.Equal(["Agent_job_1"], pipeline.jobs[2].dependsOn);
+    }
+
+    [Fact]
+    public void GenPipeline_PhaseNamesCollidingOnlyAfterSanitising_ProduceUniqueJobIdentifiers()
+    {
+        var definition = YamlizrTestData.BuildDefinitionWithPhases(
+            "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), "Build (x86)", "Build [x86]");
+
+        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+
+        Assert.Equal(["Build_x86", "Build_x86_1"], pipeline.jobs.Select(p => p.job));
+    }
+
+    [Fact]
+    public void GenPipeline_UnnamedPhases_AreGivenUniqueGeneratedNames()
+    {
+        var definition = YamlizrTestData.BuildDefinitionWithPhases(
+            "Azure Pipelines", YamlizrTestData.Step(YamlizrTestData.KnownTaskId), "   ", null);
+
+        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+
+        Assert.Equal(["Phase_1", "Phase_2"], pipeline.jobs.Select(p => p.job));
+    }
+
+    [Fact]
+    public void GenPipeline_DeployPhasesSharingOneName_ProduceUniqueJobIdentifiers()
+    {
+        var definition = YamlizrTestData.ReleaseDefinitionWithPhases("Dev", "Agent job", "Agent job");
+
+        var pipeline = YamlizrTestData.Generator(definition).GenPipeline();
+
+        Assert.Equal(["Agent_job", "Agent_job_1"], pipeline.jobs.Select(p => p.job));
+        Assert.Equal(["Agent_job"], pipeline.jobs[1].dependsOn);
     }
 
     [Fact]

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/YamlizrTestData.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/YamlizrTestData.cs
@@ -178,6 +178,55 @@ public static class YamlizrTestData
         return definition;
     }
 
+    /// <summary>Builds a classic release definition with one environment carrying a deploy phase per supplied name.</summary>
+    /// <remarks>
+    /// More than one deploy phase is required for the generator to emit jobs; the sole stage is
+    /// flattened, so a single phase would be reduced to a bare step list and hide the job identifier.
+    /// </remarks>
+    /// <param name="environmentName">Environment name, emitted as the stage.</param>
+    /// <param name="phaseNames">Deploy phase names, in rank order.</param>
+    public static ReleaseDefinition ReleaseDefinitionWithPhases(string environmentName, params string[] phaseNames)
+    {
+        var definition = new ReleaseDefinition
+        {
+            Id = 7,
+            Name = "sample release",
+            Environments = [],
+        };
+
+        var environment = new ReleaseDefinitionEnvironment
+        {
+            Name = environmentName,
+            Rank = 1,
+            DeployPhases = [],
+            Variables = new Dictionary<string, ConfigurationVariableValue>(),
+            VariableGroups = [],
+        };
+
+        var rank = 1;
+        foreach (var phaseName in phaseNames)
+            environment.DeployPhases.Add(new AgentBasedDeployPhase
+            {
+                Name = phaseName,
+                Rank = rank++,
+                DeploymentInput = new AgentDeploymentInput { Condition = "succeeded()" },
+                WorkflowTasks =
+                {
+                    new WorkflowTask
+                    {
+                        Enabled = true,
+                        Name = "sample step",
+                        TaskId = KnownTaskId,
+                        Version = "1.*",
+                        DefinitionType = "task",
+                    }
+                }
+            });
+
+        definition.Environments.Add(environment);
+        return definition;
+    }
+
     /// <summary>Creates a generator over a release definition with no task groups or variable groups.</summary>
     public static YamlPipelineGenerator Generator(ReleaseDefinition release, Dictionary<Guid, Dictionary<int, TaskObj>> taskMap = null)
         => new(

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/YamlizrTestData.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/YamlizrTestData.cs
@@ -133,47 +133,11 @@ public static class YamlizrTestData
     /// <param name="environmentNames">Environment names, in rank order.</param>
     public static ReleaseDefinition ReleaseDefinition(params string[] environmentNames)
     {
-        //the SDK leaves these collections null, unlike the build definition equivalents
-        var definition = new ReleaseDefinition
-        {
-            Id = 7,
-            Name = "sample release",
-            Environments = [],
-        };
+        var definition = NewReleaseDefinition();
 
         var rank = 1;
         foreach (var environmentName in environmentNames)
-        {
-            var environment = new ReleaseDefinitionEnvironment
-            {
-                Name = environmentName,
-                Rank = rank,
-                DeployPhases = [],
-                Variables = new Dictionary<string, ConfigurationVariableValue>(),
-                VariableGroups = [],
-            };
-
-            environment.DeployPhases.Add(new AgentBasedDeployPhase
-            {
-                Name = "Agent job",
-                Rank = 1,
-                DeploymentInput = new AgentDeploymentInput { Condition = "succeeded()" },
-                WorkflowTasks =
-                {
-                    new WorkflowTask
-                    {
-                        Enabled = true,
-                        Name = "sample step",
-                        TaskId = KnownTaskId,
-                        Version = "1.*",
-                        DefinitionType = "task",
-                    }
-                }
-            });
-
-            definition.Environments.Add(environment);
-            rank++;
-        }
+            definition.Environments.Add(NewEnvironment(environmentName, rank++, "Agent job"));
 
         return definition;
     }
@@ -187,28 +151,32 @@ public static class YamlizrTestData
     /// <param name="phaseNames">Deploy phase names, in rank order.</param>
     public static ReleaseDefinition ReleaseDefinitionWithPhases(string environmentName, params string[] phaseNames)
     {
-        var definition = new ReleaseDefinition
-        {
-            Id = 7,
-            Name = "sample release",
-            Environments = [],
-        };
+        var definition = NewReleaseDefinition();
+        definition.Environments.Add(NewEnvironment(environmentName, 1, phaseNames));
+        return definition;
+    }
 
+    //the SDK leaves these collections null, unlike the build definition equivalents
+    private static ReleaseDefinition NewReleaseDefinition()
+        => new() { Id = 7, Name = "sample release", Environments = [] };
+
+    private static ReleaseDefinitionEnvironment NewEnvironment(string name, int rank, params string[] phaseNames)
+    {
         var environment = new ReleaseDefinitionEnvironment
         {
-            Name = environmentName,
-            Rank = 1,
+            Name = name,
+            Rank = rank,
             DeployPhases = [],
             Variables = new Dictionary<string, ConfigurationVariableValue>(),
             VariableGroups = [],
         };
 
-        var rank = 1;
+        var phaseRank = 1;
         foreach (var phaseName in phaseNames)
             environment.DeployPhases.Add(new AgentBasedDeployPhase
             {
                 Name = phaseName,
-                Rank = rank++,
+                Rank = phaseRank++,
                 DeploymentInput = new AgentDeploymentInput { Condition = "succeeded()" },
                 WorkflowTasks =
                 {
@@ -223,8 +191,7 @@ public static class YamlizrTestData
                 }
             });
 
-        definition.Environments.Add(environment);
-        return definition;
+        return environment;
     }
 
     /// <summary>Creates a generator over a release definition with no task groups or variable groups.</summary>

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -159,11 +159,9 @@ public class YamlPipelineGenerator
         if (allPhases.Count > phases.Count)
             _warnings.Add($"{allPhases.Count - phases.Count} non-agent build phase(s) are not converted, see https://github.com/f2calv/yamlizr/issues/182");
         if (phases.IsNullOrEmpty()) return null;
-        //TODO(#368): inverted, this is true when the names DIFFER. Phases that all share one name get
-        //no suffix and so produce duplicate job identifiers. https://github.com/f2calv/yamlizr/issues/368
-        var duplicatePhaseNames = phases.Select(p => p.Name).Distinct().Count() > 1;
 
         // Identifiers are assigned up front, because a phase may depend on one declared after it.
+        var usedJobIds = new HashSet<string>(phases.Count, StringComparer.OrdinalIgnoreCase);
         var converted = new List<(Phase phase, string jobId, List<Step> steps)>(phases.Count);
         var j = 0;
         foreach (var phase in phases)
@@ -174,8 +172,7 @@ public class YamlPipelineGenerator
             if (steps.IsNullOrEmpty()) continue;
             //a classic phase can have no name, which used to throw from Sanitize().Replace()
             var phaseName = string.IsNullOrWhiteSpace(phase.Name) ? $"Phase {j + 1}" : phase.Name;
-            var identifier = ToIdentifier(phaseName, $"Phase_{j + 1}");
-            converted.Add((phase, duplicatePhaseNames ? $"{identifier}_{j}" : identifier, steps));
+            converted.Add((phase, ToUniqueIdentifier(phaseName, $"Phase_{j + 1}", usedJobIds), steps));
             j++;
         }
         if (converted.IsNullOrEmpty()) return null;
@@ -355,6 +352,27 @@ public class YamlPipelineGenerator
         return char.IsAsciiDigit(identifier[0]) ? $"_{identifier}" : identifier;
     }
 
+    /// <summary>
+    /// Returns the identifier for <paramref name="name"/>, suffixed only as far as needed to be unique
+    /// within <paramref name="used"/>, to which the result is added.
+    /// </summary>
+    /// <remarks>
+    /// Azure Pipelines requires job identifiers to be unique within a stage, and resolves dependsOn
+    /// case-insensitively, so uniqueness is tracked that way. Collisions are tested for rather than
+    /// predicted from the phase names, because two distinct names can sanitise to one identifier.
+    /// </remarks>
+    private static string ToUniqueIdentifier(string name, string fallback, HashSet<string> used)
+    {
+        var identifier = ToIdentifier(name, fallback);
+        if (used.Add(identifier)) return identifier;
+
+        var suffix = 1;
+        string candidate;
+        do candidate = $"{identifier}_{suffix++}";
+        while (!used.Add(candidate));
+        return candidate;
+    }
+
     StageAzDO[] GenReleaseStages()
     {
         if (_release.Environments.IsNullOrEmpty()) return null;
@@ -407,9 +425,7 @@ public class YamlPipelineGenerator
         {
             var jobName = string.Empty;
             var jobs = new List<Job>();
-            //TODO(#368): inverted as in GenBuildStage, and counted over every deploy phase rather than
-            //only those matching _phaseType. https://github.com/f2calv/yamlizr/issues/368
-            var duplicatePhaseNames = environment.DeployPhases.Select(p => p.Name).Distinct().Count() > 1;
+            var usedJobIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             //TODO(#182): --phasetype selects a single deploy phase type, the rest are skipped.
             //https://github.com/f2calv/yamlizr/issues/182
             var skipped = environment.DeployPhases.Count(p => p.PhaseType != _phaseType);
@@ -432,7 +448,7 @@ public class YamlPipelineGenerator
                     condition = GenCondition(deploymentInput.Condition),
                     dependsOn = string.IsNullOrWhiteSpace(jobName) ? null : new[] { jobName },
                     displayName = phaseName,
-                    job = duplicatePhaseNames ? $"{ToIdentifier(phaseName, $"Phase_{j + 1}")}_{j}" : ToIdentifier(phaseName, $"Phase_{j + 1}"),
+                    job = ToUniqueIdentifier(phaseName, $"Phase_{j + 1}", usedJobIds),
                     steps = new List<Step>(steps).ToArray(),
                     timeoutInMinutes = deploymentInput.TimeoutInMinutes,
                 };


### PR DESCRIPTION
Closes #368.

`duplicatePhaseNames` was inverted, so the disambiguating `_{index}` suffix was applied when phase names *differed* and withheld when they were *identical*. A classic definition names every phase `Agent job` until someone renames them, so multi-phase definitions that were never renamed produced duplicate `job:` identifiers and YAML that Azure DevOps rejects.

## Approach

The issue proposed correcting the condition to `Distinct().Count() != phases.Count`. That is still wrong, because it predicts collisions from *phase names* while the collision actually happens between *sanitised identifiers*: `Build (x86)` and `Build [x86]` are distinct names that both become `Build_x86`.

Identifiers are now tracked as they are assigned and suffixed only on a real collision:

```csharp
var identifier = ToIdentifier(name, fallback);
if (used.Add(identifier)) return identifier;
```

Both reported defects disappear as a consequence rather than needing separate fixes, including the release site computing the test over every deploy phase instead of only those matching `--phasetype`.

Two judgement calls:

- Uniqueness is tracked case-insensitively, because Azure Pipelines resolves `dependsOn` without regard to case, so `Build` and `build` would be ambiguous even though ordinal comparison treats them as distinct.
- The first occurrence stays bare and suffixes start at `_1`, giving `Agent_job`, `Agent_job_1`, `Agent_job_2`.

## Output change

As the issue anticipated, distinct phase names lose their unnecessary suffix: `A_0`, `B_1` becomes `A`, `B`. This is a change to generated output, which is why it was kept out of the previous change and given tests here.

## Acceptance criteria

- [x] No generated pipeline contains two jobs with the same `job:` identifier.
- [x] The suffix appears only where it is needed to disambiguate.
- [x] `dependsOn` refers to the identifier actually emitted for the preceding job, asserted explicitly: the third job depends on `Agent_job_1`, not on the shared phase name.
- [x] Tests cover distinct names, all-identical names, names colliding only after sanitisation, and unnamed phases, on both the build and the release path.

Beyond those, one integration test submits the all-identical-names output to the Azure DevOps preview endpoint, so "Azure DevOps accepts this" is measured rather than asserted. That is the CI gate added in #370 doing its job on the first issue after it landed.

## Verification

35 tests, 0 failed, 0 skipped, with the live preview validation configured. The unit tests are not vacuous: under the old condition all-identical names produced three bare `Agent_job` identifiers and distinct names produced `Alpha_0` and `Beta_1`, so every new assertion flips.

The README limitation row for this behaviour is removed, and a comment added in the previous change that described the `_{index}` suffix as expected is corrected.
