### PR TITLE
Fold the image smoke test into the image build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,43 +87,21 @@ jobs:
       platform: linux/amd64,linux/arm64,linux/arm/v7
       push-image: ${{ github.ref_name == github.event.repository.default_branch }}
       args: --build-arg VERSION=${{ needs.versioning.outputs.version }}
-
-  #The image job proves the image builds, not that it runs. 3.1.6 shipped an image that
-  #exited immediately with "No frameworks were found", so build a single architecture
-  #locally and execute it.
-  image-smoke-test:
-    runs-on: ubuntu-latest
-    needs: [versioning]
-    permissions:
-      contents: read #checkout
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: docker/setup-buildx-action@v4
-
-      - name: docker build --load
-        run: |
-          docker build \
-            --build-arg VERSION=${{ needs.versioning.outputs.version }} \
-            --tag yamlizr:smoke-test \
-            --load \
-            .
-
-      - name: docker run --version
-        run: |
-          VERSION=$(docker run --rm yamlizr:smoke-test --version)
-          echo "reported version: $VERSION"
-          #SourceLink may append +<sha> to the informational version, so match the prefix
-          case "$VERSION" in
-            "${{ needs.versioning.outputs.version }}"*) ;;
-            *) echo "::error::expected a version starting with ${{ needs.versioning.outputs.version }}, got $VERSION"; exit 1 ;;
-          esac
-
-      - name: docker run generate --help
-        run: docker run --rm yamlizr:smoke-test generate --help
+      #A successful build does not prove the image runs. 3.1.6 shipped one that exited immediately
+      #with "No frameworks were found". This runs on the single loaded architecture, before the
+      #multi-architecture build, which then reuses those layers rather than rebuilding them.
+      smoke-test: |
+        VERSION=$(docker run --rm $IMAGE --version)
+        echo "reported version: $VERSION"
+        #SourceLink may append +<sha> to the informational version, so match the prefix
+        case "$VERSION" in
+          "${{ needs.versioning.outputs.version }}"*) ;;
+          *) echo "::error::expected a version starting with ${{ needs.versioning.outputs.version }}, got $VERSION"; exit 1 ;;
+        esac
+        docker run --rm $IMAGE generate --help
 
   release:
-    needs: [versioning, build, image, image-smoke-test]
+    needs: [versioning, build, image]
     if: needs.versioning.outputs.release-exists == 'false'
       && (github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || inputs.push-preview == true)
     uses: f2calv/gha-workflows/.github/workflows/gha-release-versioning.yml@v1


### PR DESCRIPTION
Moves the container smoke test into the `image` job, using the `smoke-test` input added in gha-workflows v1.6.10, and deletes the separate `image-smoke-test` job.

## Why the job existed

`docker buildx build --load` accepts a single platform only, so the multi-architecture build cannot be loaded into the docker image store and cannot be executed. On a pull request, where `push-image` is false, its output goes nowhere at all. Proving the image actually starts therefore needed a second, single-architecture build in its own job.

The reusable workflow now does that build on the same buildx builder as the multi-architecture one, which reuses the layers from the builder's local cache rather than rebuilding them.

## Effect

| | Before | After |
| --- | --- | --- |
| Platform builds per run | 4 | 3 |
| Runners | 2 | 1 |

The checks themselves are unchanged: run `--version` and match it against the resolved GitVersion number, then run `generate --help`.

## Branch protection

`image-smoke-test` was a required status check on `main`. A required check that no longer reports leaves every pull request permanently pending, and `enforce_admins` is on, so it has been removed from the required list. The required checks are now `lint / lint`, `build` and `image / container-image-build`.

## Verification

actionlint reports no findings on the workflow, and the `smoke-test` input name was checked against the merged reusable workflow rather than assumed. actionlint cannot resolve a remote reusable workflow's inputs, so a wrong name would not have been caught by linting alone.

Cache reuse across differing `--platform` sets is expected rather than guaranteed for every buildkit version. This run's `image` job log should show `CACHED` against the amd64 layers during the multi-architecture build; if it does not, the run still passes and correctness is unaffected, but the saving is not being realised.
