### PR TITLE
Expand the fixtures, document conversion coverage, and split out two issues

### DIFF
--- a/.scripts/New-FixtureDefinitions.ps1
+++ b/.scripts/New-FixtureDefinitions.ps1
@@ -398,9 +398,11 @@ function New-TaskStep {
         [Parameter(Mandatory)][string]$TaskName,
         [Parameter(Mandatory)][string]$DisplayName,
         [hashtable]$Inputs = @{},
+        [hashtable]$Environment = @{},
         [bool]$Enabled = $true,
         [bool]$ContinueOnError = $false,
         [bool]$AlwaysRun = $false,
+        [int]$TimeoutInMinutes = 0,
         [string]$Condition = 'succeeded()'
     )
 
@@ -411,16 +413,45 @@ function New-TaskStep {
     $task = $script:Tasks[$TaskName]
 
     return @{
-        environment      = @{}
+        environment      = $Environment
         enabled          = $Enabled
         continueOnError  = $ContinueOnError
         alwaysRun        = $AlwaysRun
         displayName      = $DisplayName
-        timeoutInMinutes = 0
+        timeoutInMinutes = $TimeoutInMinutes
         condition        = $Condition
         task             = @{ id = $task.Id; versionSpec = $task.VersionSpec; definitionType = 'task' }
         inputs           = $Inputs
     }
+}
+
+function New-OptionalTaskStep {
+    <#
+    .SYNOPSIS
+        Builds a step only when the task is installed, warning and omitting it when it is not.
+    .DESCRIPTION
+        The in-box task catalogue varies between organisations, so a fixture spanning many tasks would
+        otherwise fail outright on the first one that is absent rather than building what it can.
+    #>
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory)][string]$TaskName,
+        [Parameter(Mandatory)][string]$DisplayName,
+        [hashtable]$Inputs = @{},
+        [hashtable]$Environment = @{},
+        [bool]$ContinueOnError = $false,
+        [int]$TimeoutInMinutes = 0,
+        [string]$Condition = 'succeeded()'
+    )
+
+    if (-not $script:Tasks.ContainsKey($TaskName)) {
+        Write-Warning "Task '$TaskName' is not installed, so the '$DisplayName' step is omitted from the fixture."
+        return
+    }
+
+    return New-TaskStep -TaskName $TaskName -DisplayName $DisplayName -Inputs $Inputs -Environment $Environment `
+        -ContinueOnError $ContinueOnError -TimeoutInMinutes $TimeoutInMinutes -Condition $Condition
 }
 
 function New-TaskGroupStep {
@@ -908,6 +939,76 @@ function New-FixtureBuildDefinitions {
             New-TaskStep -TaskName 'PowerShell' -DisplayName 'Multi-line PowerShell' -Inputs @{ targetType = 'inline'; script = $script:MultiLinePowerShell }
             New-TaskStep -TaskName 'CmdLine' -DisplayName 'Multi-line cmd with trailing blank line' -Inputs @{ script = "echo one`necho two`n`n" }
             New-TaskStep -TaskName 'Bash' -DisplayName 'Script that is only whitespace' -Inputs @{ targetType = 'inline'; script = "   `n   `n" }
+        )
+    )
+
+    # A spread of in-box tasks, so the generated YAML is more than script steps, and the step level
+    # env, timeout and continueOnError the README claims to convert are actually exercised.
+    $created.TaskVariety = Set-FixtureBuildDefinition -Name "$($script:Prefix)task-variety" -Phases @(
+        New-AgentPhase -Name 'Restore and build' -RefName 'Phase_1' -Steps @(
+            New-OptionalTaskStep -TaskName 'UseDotNet' -DisplayName 'Use the .NET SDK' -Inputs @{
+                packageType = 'sdk'
+                version     = '8.0.x'
+            }
+            New-OptionalTaskStep -TaskName 'NuGetToolInstaller' -DisplayName 'Install NuGet' -Inputs @{ versionSpec = '6.x' }
+            New-OptionalTaskStep -TaskName 'NuGetCommand' -DisplayName 'NuGet restore' -Inputs @{
+                command         = 'restore'
+                restoreSolution = '**/*.sln'
+            }
+            New-OptionalTaskStep -TaskName 'DotNetCoreCLI' -DisplayName 'dotnet build' -Inputs @{
+                command   = 'build'
+                projects  = '**/*.csproj'
+                arguments = '--configuration $(BuildConfiguration) --no-restore'
+            }
+            New-OptionalTaskStep -TaskName 'MSBuild' -DisplayName 'MSBuild with arguments' -Inputs @{
+                solution         = '**/*.sln'
+                configuration    = '$(BuildConfiguration)'
+                msbuildArguments = '/p:DeployOnBuild=true'
+            }
+            New-OptionalTaskStep -TaskName 'NodeTool' -DisplayName 'Use Node' -Inputs @{ versionSpec = '20.x' }
+            New-OptionalTaskStep -TaskName 'Npm' -DisplayName 'npm ci' -Inputs @{
+                command    = 'ci'
+                workingDir = 'src/web'
+            }
+        )
+        New-AgentPhase -Name 'Test and package' -RefName 'Phase_2' -DependsOn @('Phase_1') -Steps @(
+            New-OptionalTaskStep -TaskName 'DotNetCoreCLI' -DisplayName 'dotnet test, tolerating failure' `
+                -ContinueOnError $true -TimeoutInMinutes 15 `
+                -Environment @{
+                DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true'
+                DOTNET_CLI_TELEMETRY_OPTOUT       = '1'
+            } -Inputs @{
+                command   = 'test'
+                projects  = '**/*Tests.csproj'
+                arguments = '--configuration $(BuildConfiguration) --collect:"XPlat Code Coverage"'
+            }
+            New-OptionalTaskStep -TaskName 'PublishTestResults' -DisplayName 'Publish test results' -Condition 'succeededOrFailed()' -Inputs @{
+                testResultsFormat = 'VSTest'
+                testResultsFiles  = '**/*.trx'
+                mergeTestResults  = 'true'
+            }
+            New-OptionalTaskStep -TaskName 'PublishCodeCoverageResults' -DisplayName 'Publish coverage' -Condition 'succeededOrFailed()' -Inputs @{
+                summaryFileLocation = '$(Agent.TempDirectory)/**/coverage.cobertura.xml'
+            }
+            New-OptionalTaskStep -TaskName 'CopyFiles' -DisplayName 'Stage the output' -Inputs @{
+                SourceFolder = '$(Build.SourcesDirectory)'
+                Contents     = '**/bin/$(BuildConfiguration)/**'
+                TargetFolder = '$(Build.ArtifactStagingDirectory)'
+            }
+            New-OptionalTaskStep -TaskName 'ArchiveFiles' -DisplayName 'Archive the staged output' -Inputs @{
+                rootFolderOrFile  = '$(Build.ArtifactStagingDirectory)'
+                includeRootFolder = 'false'
+                archiveType       = 'zip'
+                archiveFile       = '$(Build.ArtifactStagingDirectory)/package.zip'
+            }
+            New-OptionalTaskStep -TaskName 'PublishPipelineArtifact' -DisplayName 'Publish the package' -Inputs @{
+                targetPath = '$(Build.ArtifactStagingDirectory)/package.zip'
+                artifact   = 'package'
+            }
+            New-OptionalTaskStep -TaskName 'DeleteFiles' -DisplayName 'Clean the staging directory' -Condition 'always()' -Inputs @{
+                SourceFolder = '$(Build.ArtifactStagingDirectory)'
+                Contents     = '**/*'
+            }
         )
     )
 

--- a/.scripts/New-FixtureDefinitions.ps1
+++ b/.scripts/New-FixtureDefinitions.ps1
@@ -627,6 +627,43 @@ function Set-FixtureVariableGroup {
         -Uri "$script:ProjectUri/_apis/distributedtask/variablegroups?api-version=$script:VariableGroupApiVersion"
 }
 
+function Set-FixtureDeploymentGroup {
+    <#
+    .SYNOPSIS
+        Creates or updates a deployment group by name.
+    .DESCRIPTION
+        The group is deliberately left with no registered targets. A classic deployment group phase is
+        a construct yamlizr does not convert, so the fixture only needs the phase to exist, and
+        registering a target would mean running an agent.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)][string]$Name,
+        [Parameter(Mandatory)][string]$Description
+    )
+
+    $existing = Get-AdoCollection -Uri "$script:ProjectUri/_apis/distributedtask/deploymentgroups?api-version=$script:PreviewApiVersion" |
+        Where-Object { $_.name -eq $Name } |
+        Select-Object -First 1
+
+    if ($existing) {
+        Write-Host "Deployment group '$Name' already exists." -ForegroundColor DarkGray
+        return $existing
+    }
+
+    if (-not $PSCmdlet.ShouldProcess($Name, 'Create deployment group')) { return $null }
+    Write-Host "Creating deployment group '$Name'." -ForegroundColor DarkGray
+
+    try {
+        return Invoke-AdoApi -Method Post -Body @{ name = $Name; description = $Description } `
+            -Uri "$script:ProjectUri/_apis/distributedtask/deploymentgroups?api-version=$script:PreviewApiVersion"
+    }
+    catch {
+        Write-Warning "Could not create deployment group '$Name', so the deployment group phase is skipped: $($_.Exception.Message)"
+        return $null
+    }
+}
+
 function Set-FixtureTaskGroup {
     <#
     .SYNOPSIS
@@ -1185,6 +1222,7 @@ function New-FixtureReleaseDefinition {
             [bool]$ManualApproval,
             [string]$AfterEnvironment,
             [hashtable]$Variables = @{},
+            [int]$DeploymentGroupId = 0,
             [hashtable]$PreDeploymentGates = @{ id = 0; gatesOptions = $null; gates = @() }
         )
 
@@ -1201,6 +1239,52 @@ function New-FixtureReleaseDefinition {
         }
         else {
             @(@{ rank = 1; isAutomated = $true; isNotificationOn = $false; id = 0 })
+        }
+
+        $deployPhases = @(@{
+                rank            = 1
+                phaseType       = 'agentBasedDeployment'
+                name            = 'Agent job'
+                refName         = $null
+                workflowTasks   = @($Tasks | ForEach-Object { ConvertTo-WorkflowTask -Step $_ })
+                deploymentInput = @{
+                    parallelExecution         = @{ parallelExecutionType = 'none' }
+                    agentSpecification        = $null
+                    skipArtifactsDownload     = $false
+                    artifactsDownloadInput    = @{}
+                    queueId                   = $script:QueueId
+                    demands                   = @()
+                    enableAccessToken         = $false
+                    timeoutInMinutes          = 0
+                    jobCancelTimeoutInMinutes = 1
+                    condition                 = 'succeeded()'
+                    overrideInputs            = @{}
+                }
+            })
+
+        # yamlizr converts only the phase type given by --phasetype, so this second phase is expected
+        # to be skipped and reported. For a deployment group phase queueId carries the group id.
+        if ($DeploymentGroupId -gt 0) {
+            $deployPhases += @{
+                rank            = 2
+                phaseType       = 'machineGroupBasedDeployment'
+                name            = 'Deployment group phase'
+                refName         = $null
+                workflowTasks   = @($Tasks | ForEach-Object { ConvertTo-WorkflowTask -Step $_ })
+                deploymentInput = @{
+                    parallelExecution         = @{ parallelExecutionType = 'none' }
+                    skipArtifactsDownload     = $false
+                    artifactsDownloadInput    = @{}
+                    queueId                   = $DeploymentGroupId
+                    demands                   = @()
+                    enableAccessToken         = $false
+                    timeoutInMinutes          = 0
+                    jobCancelTimeoutInMinutes = 1
+                    condition                 = 'succeeded()'
+                    overrideInputs            = @{}
+                    tags                      = @()
+                }
+            }
         }
 
         # @() matters on every one of these. A single-element array collapses to a bare object when
@@ -1231,26 +1315,7 @@ function New-FixtureReleaseDefinition {
             preDeploymentGates  = $PreDeploymentGates
             postDeploymentGates = @{ id = 0; gatesOptions = $null; gates = @() }
             deployStep          = @{ id = 0 }
-            deployPhases        = @(@{
-                    rank            = 1
-                    phaseType       = 'agentBasedDeployment'
-                    name            = 'Agent job'
-                    refName         = $null
-                    workflowTasks   = @($Tasks | ForEach-Object { ConvertTo-WorkflowTask -Step $_ })
-                    deploymentInput = @{
-                        parallelExecution            = @{ parallelExecutionType = 'none' }
-                        agentSpecification           = $null
-                        skipArtifactsDownload        = $false
-                        artifactsDownloadInput       = @{}
-                        queueId                      = $script:QueueId
-                        demands                      = @()
-                        enableAccessToken            = $false
-                        timeoutInMinutes             = 0
-                        jobCancelTimeoutInMinutes    = 1
-                        condition                    = 'succeeded()'
-                        overrideInputs               = @{}
-                    }
-                })
+            deployPhases        = @($deployPhases)
         }
     }
 
@@ -1274,6 +1339,10 @@ function New-FixtureReleaseDefinition {
         New-TaskStep -TaskName 'PowerShell' -DisplayName 'Production script' -Inputs @{ targetType = 'inline'; script = $script:MultiLinePowerShell }
     )
 
+    $deploymentGroup = Set-FixtureDeploymentGroup -Name "$($script:Prefix)deployment-group" `
+        -Description 'Fixture deployment group with no registered targets, used only to carry a deployment group phase.'
+    $deploymentGroupId = if ($deploymentGroup) { [int]$deploymentGroup.id } else { 0 }
+
     $environments = @(
         New-Environment -Name 'Dev' -Rank 1 -Tasks $devTasks -ManualApproval $false -Variables @{
             'fixture.stage' = @{ value = 'dev' }
@@ -1281,7 +1350,7 @@ function New-FixtureReleaseDefinition {
         New-Environment -Name 'Test' -Rank 2 -Tasks $testTasks -ManualApproval $true -AfterEnvironment 'Dev' -Variables @{
             'fixture.stage' = @{ value = 'test' }
         }
-        New-Environment -Name 'Prod' -Rank 3 -Tasks $prodTasks -ManualApproval $true -AfterEnvironment 'Test' -PreDeploymentGates $gates -Variables @{
+        New-Environment -Name 'Prod' -Rank 3 -Tasks $prodTasks -ManualApproval $true -AfterEnvironment 'Test' -PreDeploymentGates $gates -DeploymentGroupId $deploymentGroupId -Variables @{
             'fixture.stage' = @{ value = 'prod' }
         }
     )

--- a/.scripts/README.md
+++ b/.scripts/README.md
@@ -92,6 +92,7 @@ Names below assume the default prefix.
 | `yamlizr.test.Nested Task Group` | Calls the task group above, covering recursive expansion |
 | `yamlizr.test.common` | A variable group carrying plain, spaced and secret values |
 | `yamlizr.test.release-multi-stage` | Three environments, a build artifact, automated and manual pre-deployment approvals, stage-after-stage conditions, a continuous deployment trigger, stage-scoped variables, a disabled step and an optional gate |
+| `yamlizr.test.deployment-group` | A deployment group with no registered targets, carrying the deployment group phase on the Prod stage so the phase type yamlizr skips is exercised |
 | `yamlizr.test.validation` | An empty YAML pipeline used only as a target for validating generated YAML. Deliberately the one fixture left enabled |
 
 No value in the fixture is a real credential, and no definition is ever queued.

--- a/.scripts/README.md
+++ b/.scripts/README.md
@@ -44,7 +44,7 @@ $token = Read-Host 'PAT' -MaskInput
 ./.scripts/New-FixtureDefinitions.ps1 -OrganisationUri https://dev.azure.com/contoso -Project demo -Pat $token
 ```
 
-Required scopes for the full-access token: Project and Team (read), Build (read and execute), Release (read, write, execute and manage), Task Groups (read, create and manage), Variable Groups (read, create and manage).
+Required scopes for the full-access token: Project and Team (read), Build (read and execute), Release (read, write, execute and manage), Task Groups (read, create and manage), Variable Groups (read, create and manage), Deployment Groups (read and manage).
 
 `Code` is deliberately not required. A classic Build definition must name a repository, and the binding for a GitHub repository carries a service connection id plus a page of provider metadata that cannot be reconstructed from a repository name. The script copies that binding from an existing definition rather than enumerating Azure Repos, which would need `Code` and would fail in an organisation that has no Azure Repos repository. Nothing is ever pushed to the borrowed repository, and no fixture definition is ever queued.
 

--- a/.scripts/README.md
+++ b/.scripts/README.md
@@ -84,6 +84,7 @@ Names below assume the default prefix.
 | `yamlizr.test.multi-phase` | Three agent phases, phase-to-phase dependencies, a fan-in, and a phase condition other than `succeeded()` |
 | `yamlizr.test.server-phase` | An agentless phase next to an agent phase, so the phase yamlizr skips is exercised |
 | `yamlizr.test.multiline-scripts` | Multi-line Bash, PowerShell and cmd scripts, a trailing blank line, and a whitespace-only script |
+| `yamlizr.test.task-variety` | Fourteen in-box tasks across two phases, covering step-level `env`, `timeoutInMinutes`, `continueOnError` and conditions other than `succeeded()` |
 | `yamlizr.test.task-groups` | A task group whose name contains spaces, referenced four times: defaults kept, defaults overridden, nested, and disabled |
 | `yamlizr.test.triggers-and-variables` | Continuous integration, pull request and scheduled triggers with branch and path filters, definition variables including a secret and one settable at queue time, and a linked variable group |
 | `yamlizr.test.uninstalled-extension` | A step whose task is not installed, covering the null path in [issue #177](https://github.com/f2calv/yamlizr/issues/177). Only created with `-IncludeUnknownTask` |

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ All generated YAML is written into sub-folders of a project folder, so a run wit
 - `c:/temp/myoutputfolder/<your AzDO project>/GitHubReleases/*.yml` (with `--githubactions`)
 
 Each run finishes with a summary of anything it could not convert, see
-[Known Limitations](#known-limitations).
+[Conversion Coverage](#conversion-coverage).
 
 ## Configuration
 
@@ -282,30 +282,59 @@ This _is not_ a delicate tool to create perfectly constructed YAML pipelines. In
 
 With `--githubactions` the same Azure DevOps Pipeline objects are additionally passed into the [AzurePipelinesToGitHubActionsConverter library](https://github.com/samsmithnz/AzurePipelinesToGitHubActionsConverter) (by [@samsmithnz](https://github.com/samsmithnz)) and exported as GitHub Actions compliant workflows.
 
-## Known Limitations
+## Conversion Coverage
 
-The tool converts as much of a classic definition as it can and reports whatever it cannot. Anything
-listed below is **absent from the generated YAML** and must be re-created by hand. Every run prints a
-summary of the constructs it skipped, naming the definition and the construct, so nothing is dropped
-without a trace. Progress on closing these gaps is tracked in
+Every run finishes with a summary naming each construct it could not convert and the definition it
+came from, so nothing is dropped without a trace. Anything marked ❌ below is **absent from the
+generated YAML** and must be re-created by hand. Progress on closing these gaps is tracked in
 [issue #182](https://github.com/f2calv/yamlizr/issues/182).
 
-| Classic construct | Status |
-| --- | --- |
-| Release artifacts | Not converted; a generated release pipeline has no inputs. |
-| Pre- and post-deployment approvals and gates | Not converted. |
-| Stage inter-dependencies (`dependsOn`) | Not converted; generated stages run concurrently rather than in the classic environment order. |
-| Non-agent build phases (server, deployment group) | Not converted. |
-| Deploy phases other than `--phasetype` | Not converted. |
-| Triggers other than continuous integration (pull request, scheduled, build completion) | Not converted. |
-| Steps referencing an uninstalled extension | Not converted; reported by name and task id. |
-| Stage or job settings on a single-stage or single-job definition | A lone stage or job is flattened into a bare step list, dropping stage-level variables and a non-default job condition. |
-| Combined build plus release multi-stage pipelines | Build and release definitions are emitted as separate files. |
+✅ converted &nbsp;&nbsp; ⚠️ partially converted &nbsp;&nbsp; ❌ not converted
+
+### Build Definitions
+
+| Classic construct | | Notes |
+| --- | :-: | --- |
+| Agent phases | ✅ | Each phase becomes a job. |
+| Job `dependsOn` | ✅ | Mapped from the phase's declared dependencies, including fan-in, so phases meant to run in parallel still do. |
+| Job condition, timeout and cancel timeout | ✅ | |
+| Agent queue | ✅ | Becomes the pipeline `pool`. |
+| Continuous integration trigger | ✅ | Including branch and path include/exclude filters, and batching. |
+| Pull request, scheduled and build completion triggers | ❌ | Reported in the run summary. |
+| Server and deployment group phases | ❌ | Only agent phases are converted. |
+| A definition with exactly one job | ⚠️ | Flattened to a bare step list, dropping a non-default job condition, see [issue #211](https://github.com/f2calv/yamlizr/issues/211). |
+
+### Release Definitions
+
+| Classic construct | | Notes |
+| --- | :-: | --- |
+| Environments | ✅ | Each environment becomes a stage named after it. |
+| Deploy phases matching `--phasetype` | ✅ | Defaults to `AgentBasedDeployment`. |
+| Job `dependsOn` within a stage | ✅ | Sequential, in rank order. |
+| Job condition, timeout and cancel timeout | ✅ | |
+| Stage `dependsOn` | ❌ | Generated stages run concurrently rather than in the classic environment order. |
+| Release artifacts | ❌ | A generated release pipeline therefore has no inputs. |
+| Pre- and post-deployment approvals and gates | ❌ | Detected and reported, but not converted. |
+| Deploy phases other than `--phasetype` | ❌ | Reported per stage. |
+| A definition with exactly one stage | ⚠️ | Flattened, dropping stage-level variables and variable groups, see [issue #211](https://github.com/f2calv/yamlizr/issues/211). |
+
+### Steps, Variables and Task Groups
+
+| Classic construct | | Notes |
+| --- | :-: | --- |
+| Steps for installed tasks | ✅ | With `condition`, `continueOnError`, `timeoutInMinutes` and `env`. |
+| Task groups | ✅ | Emitted as template files, or merged into the calling job with `--inline`. |
+| Task group parameters | ✅ | Become template parameters. |
+| Variables | ✅ | Pipeline, stage and environment scope. |
+| Variable groups | ✅ | Emitted as a `group` reference. |
+| GitHub Actions workflows | ✅ | With `--githubactions`, via [AzurePipelinesToGitHubActionsConverter](https://github.com/samsmithnz/AzurePipelinesToGitHubActionsConverter). |
+| Steps referencing an extension not installed in the organisation | ❌ | Reported by display name and task id. |
+| Steps whose task version cannot be parsed | ❌ | Reported by display name and task id. |
+| Combined build plus release multi-stage pipelines | ❌ | Build and release definitions are emitted as separate files. |
 
 ## Known Issues
 
-- ShellProgressBar gives random formatting problems.
-- Various YAML structures are 'missing', PR's welcome.
+- ShellProgressBar occasionally corrupts its own output; the console writes a blank line after each bar as a workaround.
 
 ## Core Dependencies
 

--- a/README.md
+++ b/README.md
@@ -332,10 +332,6 @@ generated YAML** and must be re-created by hand. Progress on closing these gaps 
 | Steps whose task version cannot be parsed | ❌ | Reported by display name and task id. |
 | Combined build plus release multi-stage pipelines | ❌ | Build and release definitions are emitted as separate files. |
 
-## Known Issues
-
-- ShellProgressBar occasionally corrupts its own output; the console writes a blank line after each bar as a workaround.
-
 ## Core Dependencies
 
 - [Azure DevOps .NET Client Libraries](https://docs.microsoft.com/en-us/azure/devops/integrate/concepts/dotnet-client-libraries?view=azure-devops)

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ generated YAML** and must be re-created by hand. Progress on closing these gaps 
 | Job condition, timeout and cancel timeout | ✅ | |
 | Stage `dependsOn` | ❌ | Generated stages run concurrently rather than in the classic environment order. |
 | Release artifacts | ❌ | A generated release pipeline therefore has no inputs. |
-| Pre- and post-deployment approvals and gates | ❌ | Detected and reported, but not converted. |
+| Pre- and post-deployment approvals and gates | ❌ | Detected and reported, but not converted, see [issue #374](https://github.com/f2calv/yamlizr/issues/374). A generated release pipeline deploys straight through where the classic definition had a gate. |
 | Deploy phases other than `--phasetype` | ❌ | Reported per stage. |
 | A definition with exactly one stage | ⚠️ | Flattened, dropping stage-level variables and variable groups, see [issue #211](https://github.com/f2calv/yamlizr/issues/211). |
 

--- a/src/CasCap.Api.AzureDevOps.Tests/README.md
+++ b/src/CasCap.Api.AzureDevOps.Tests/README.md
@@ -21,9 +21,9 @@ Tests/
 
 | Suite | Test methods | Expanded cases |
 | --- | --- | --- |
-| Unit | 18 | 27 |
+| Unit | 19 | 28 |
 | Integration | 8 | 8 |
-| **Total** | **26** | **35** |
+| **Total** | **27** | **36** |
 
 ## Trait Categories
 

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/Unit/YamlPipelineGeneratorTests.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/Unit/YamlPipelineGeneratorTests.cs
@@ -208,6 +208,21 @@ public class YamlPipelineGeneratorTests
         Assert.Equal(["Agent_job"], pipeline.jobs[1].dependsOn);
     }
 
+    //the README claims a deploy phase of another type is reported, and nothing asserted the warning
+    [Fact]
+    public void GenPipeline_DeployPhaseOfAnotherType_IsSkippedAndReported()
+    {
+        var generator = YamlizrTestData.Generator(
+            YamlizrTestData.ReleaseDefinitionWithADeploymentGroupPhase("Prod"));
+
+        var pipeline = generator.GenPipeline();
+
+        //only the agent phase survives, so the sole remaining job is flattened to steps
+        Assert.NotNull(pipeline.steps);
+        Assert.Contains(generator.Warnings, p =>
+            p.Contains("deploy phase(s) that are not") && p.Contains("AgentBasedDeployment"));
+    }
+
     [Fact]
     public void GenPipeline_NeitherBuildNorRelease_IsRejected()
     {

--- a/src/CasCap.Api.AzureDevOps.Tests/Tests/YamlizrTestData.cs
+++ b/src/CasCap.Api.AzureDevOps.Tests/Tests/YamlizrTestData.cs
@@ -194,6 +194,38 @@ public static class YamlizrTestData
         return environment;
     }
 
+    /// <summary>
+    /// Builds a release definition whose single environment carries an agent phase and a deployment
+    /// group phase, which the generator is expected to skip and report.
+    /// </summary>
+    /// <param name="environmentName">Environment name, emitted as the stage.</param>
+    public static ReleaseDefinition ReleaseDefinitionWithADeploymentGroupPhase(string environmentName)
+    {
+        var definition = NewReleaseDefinition();
+        var environment = NewEnvironment(environmentName, 1, "Agent job");
+
+        environment.DeployPhases.Add(new MachineGroupBasedDeployPhase
+        {
+            Name = "Deployment group phase",
+            Rank = 2,
+            DeploymentInput = new MachineGroupDeploymentInput { Condition = "succeeded()" },
+            WorkflowTasks =
+            {
+                new WorkflowTask
+                {
+                    Enabled = true,
+                    Name = "sample step",
+                    TaskId = KnownTaskId,
+                    Version = "1.*",
+                    DefinitionType = "task",
+                }
+            }
+        });
+
+        definition.Environments.Add(environment);
+        return definition;
+    }
+
     /// <summary>Creates a generator over a release definition with no task groups or variable groups.</summary>
     public static YamlPipelineGenerator Generator(ReleaseDefinition release, Dictionary<Guid, Dictionary<int, TaskObj>> taskMap = null)
         => new(

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -389,11 +389,11 @@ public class YamlPipelineGenerator
             var jobs = GenJobs(environment);
             if (jobs.IsNullOrEmpty()) continue;
 
-            //TODO(#182): pre- and post-deployment approvals and gates should become an Environment
-            //with approval checks, or at minimum a documented manual step.
-            //https://github.com/f2calv/yamlizr/issues/182
+            //TODO(#374): approvals and gates have no in-document YAML equivalent. The stage needs to
+            //emit a deployment job targeting an Environment, and the checks are configured on that
+            //Environment outside the pipeline. https://github.com/f2calv/yamlizr/issues/374
             if (HasApprovals(environment))
-                _warnings.Add($"stage '{environment.Name}' has deployment approvals or gates which are not converted, see https://github.com/f2calv/yamlizr/issues/182");
+                _warnings.Add($"stage '{environment.Name}' has deployment approvals or gates which are not converted, see https://github.com/f2calv/yamlizr/issues/374");
 
             //TODO(#182): environment.Conditions carries the classic stage trigger, including
             //artifact and environment dependencies, which should become stage dependsOn/condition.

--- a/src/CasCap.DevOpsYamlizrCli/Commands/GenerateCommand.cs
+++ b/src/CasCap.DevOpsYamlizrCli/Commands/GenerateCommand.cs
@@ -236,7 +236,9 @@ class GenerateCommand : CommandBase
                     ProcessDefinition(buildDefinition);
 
             pbar.Dispose();
-            _console.WriteLine();//for some reason the progressbar gets corrupted so temporarily add blank line...
+            //TODO(#373): ShellProgressBar corrupts its own output, so a blank line follows every bar.
+            //https://github.com/f2calv/yamlizr/issues/373
+            _console.WriteLine();
 
             void ProcessDefinition(BuildDefinition buildDefinition)
             {
@@ -288,7 +290,8 @@ class GenerateCommand : CommandBase
                     await ProcessDefinition(releaseDefinition);
 
             pbar.Dispose();
-            _console.WriteLine();//for some reason the progressbar gets corrupted so temporarily add blank line...
+            //TODO(#373): see the note on the build definition bar above.
+            _console.WriteLine();
 
             async Task ProcessDefinition(ReleaseDefinition releaseDefinition)
             {
@@ -348,7 +351,8 @@ class GenerateCommand : CommandBase
             await Parallel.ForEachAsync(definitions, async (result, token) => await ProcessDefinition(result));
 
             pbar.Dispose();
-            _console.WriteLine();//for some reason the progressbar gets corrupted so temporarily add blank line...
+            //TODO(#373): see the note on the build definition bar above.
+            _console.WriteLine();
 
             async Task ProcessDefinition((BuildDefinition buildDefinition, ReleaseDefinition releaseDefinition, Pipeline pipeline) result)
             {
@@ -379,7 +383,8 @@ class GenerateCommand : CommandBase
             await Parallel.ForEachAsync(definitions, async (result, token) => await ProcessDefinition(result));
 
             pbar.Dispose();
-            _console.WriteLine();//for some reason the progressbar gets corrupted so temporarily add blank line...
+            //TODO(#373): see the note on the build definition bar above.
+            _console.WriteLine();
 
             async Task ProcessDefinition((BuildDefinition buildDefinition, ReleaseDefinition releaseDefinition, Pipeline pipeline) result)
             {


### PR DESCRIPTION
Expands the conversion fixtures, and replaces the README's list of what the tool cannot do with a table of what it can.

## Conversion coverage in the README

The old *Known Limitations* list only recorded gaps, so a reader could not tell whether variables, variable groups, task groups, task group parameters, step `condition`/`continueOnError`/`timeoutInMinutes`/`env`, job timeouts, CI branch and path filters or build job `dependsOn` were handled at all. Every entry read as a flat "no".

Three tables now cover build definitions, release definitions and steps, each marking a construct ✅ converted, ⚠️ partially converted or ❌ not converted.

Every row was verified against the generator rather than carried over. **All nine original limitations are still real**, so none could simply be deleted, but two needed splitting rather than a flat "no":

- **`dependsOn`** — build *jobs* now map real phase dependencies; release *stages* still get none
- **Triggers** — CI is converted with branch and path filters; pull request, scheduled and build completion are not

## Fixtures

- **`yamlizr.test.task-variety`** — fourteen in-box tasks across two phases: SDK and tool installers, restore, build, test, publish and file manipulation. Every existing build fixture used script tasks, so conversion of a real task with typed inputs was never exercised.
- **`yamlizr.test.deployment-group`** — a deployment group with no registered targets, carrying a `machineGroupBasedDeployment` phase on the Prod stage. The phase only has to exist; registering a target would mean running an agent.

`New-TaskStep` gained `-Environment` and `-TimeoutInMinutes`, because it hard-coded `environment = @{}` and `timeoutInMinutes = 0` — so the step `env` and `timeoutInMinutes` the README claims to convert *could not* have been covered by any fixture. `New-OptionalTaskStep` omits a step whose task is absent rather than failing the whole run, since the in-box catalogue varies between organisations.

## A test that was passing for the wrong reason

`FixtureConversionTests` only asserts Azure DevOps accepts the generated YAML. A generator that silently dropped the new deployment group phase would still have passed, because the resulting YAML is perfectly valid — it is just missing something.

The warning is the actual contract for every ❌ row, so there is now an offline test asserting the deploy phase type warning fires. The same blind spot still applies to the server phase, release artifacts, approvals and stage `dependsOn`.

## Two issues split out

- **#373** — replace ShellProgressBar, probably with Spectre.Console. Four sites wrote a blank line after disposing a bar, each describing itself as temporary with no record of why. They now carry `TODO(#373)`, and the README note is gone.
- **#374** — convert approvals and gates to an environment with checks. This was one bullet inside #182, which understated it: unlike every other gap it cannot be closed inside the YAML document, because checks live on an Environment resource configured outside the pipeline. Closing it needs a decision about whether yamlizr starts *writing* to Azure DevOps, which would break the read-only property the integration tests rely on.

The README now states the consequence plainly: a generated release pipeline deploys straight through where the classic definition had a gate.

## Not done, deliberately

An ADO Environment fixture. Classic release environments are stages and are already covered; ADO Environments are only referenced by YAML `deployment:` jobs, which yamlizr never emits. The fixture would exercise no code path and would sit unused until #374 is started.

## Verification

36 tests, 0 failed, 0 skipped, including the live Azure DevOps preview validation of every fixture. Both new fixtures were created in the fixture organisation and convert to YAML that Azure DevOps accepts.

Azure DevOps rejects `deploymentHealthOption` on a deployment group phase, so those inputs are left to default.
