### PR TITLE
Point the flattening warnings at an issue rather than a pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ generated YAML** and must be re-created by hand. Progress on closing these gaps 
 | Continuous integration trigger | ✅ | Including branch and path include/exclude filters, and batching. |
 | Pull request, scheduled and build completion triggers | ❌ | Reported in the run summary. |
 | Server and deployment group phases | ❌ | Only agent phases are converted. |
-| A definition with exactly one job | ⚠️ | Flattened to a bare step list, dropping a non-default job condition, see [issue #211](https://github.com/f2calv/yamlizr/issues/211). |
+| A definition with exactly one job | ⚠️ | Flattened to a bare step list, dropping a non-default job condition, see [issue #376](https://github.com/f2calv/yamlizr/issues/376). |
 
 ### Release Definitions
 
@@ -316,7 +316,7 @@ generated YAML** and must be re-created by hand. Progress on closing these gaps 
 | Release artifacts | ❌ | A generated release pipeline therefore has no inputs. |
 | Pre- and post-deployment approvals and gates | ❌ | Detected and reported, but not converted, see [issue #374](https://github.com/f2calv/yamlizr/issues/374). A generated release pipeline deploys straight through where the classic definition had a gate. |
 | Deploy phases other than `--phasetype` | ❌ | Reported per stage. |
-| A definition with exactly one stage | ⚠️ | Flattened, dropping stage-level variables and variable groups, see [issue #211](https://github.com/f2calv/yamlizr/issues/211). |
+| A definition with exactly one stage | ⚠️ | Flattened, dropping stage-level variables and variable groups, see [issue #376](https://github.com/f2calv/yamlizr/issues/376). |
 
 ### Steps, Variables and Task Groups
 

--- a/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
+++ b/src/CasCap.Api.AzureDevOps/Utilities/YamlPipelineGenerator.cs
@@ -113,7 +113,7 @@ public class YamlPipelineGenerator
                     //default condition is not worth reporting
                     var job = buildStage.jobs[0];
                     if (job.condition is not null && job.condition != "succeeded()")
-                        _warnings.Add($"job '{job.job}' is the only job so its steps were flattened, dropping its condition '{job.condition}', see https://github.com/f2calv/yamlizr/issues/211");
+                        _warnings.Add($"job '{job.job}' is the only job so its steps were flattened, dropping its condition '{job.condition}', see https://github.com/f2calv/yamlizr/issues/376");
                     steps.AddRange(job.steps);
                 }
                 else
@@ -132,7 +132,7 @@ public class YamlPipelineGenerator
                     //are the environment-scoped variables and variable groups
                     var stage = releaseStages[0];
                     if (!stage.variables.IsNullOrEmpty())
-                        _warnings.Add($"stage '{stage.stage}' is the only stage so it was flattened, dropping {stage.variables.Count} stage-level variable(s), see https://github.com/f2calv/yamlizr/issues/211");
+                        _warnings.Add($"stage '{stage.stage}' is the only stage so it was flattened, dropping {stage.variables.Count} stage-level variable(s), see https://github.com/f2calv/yamlizr/issues/376");
                     if (stage.jobs.Length == 1)
                         steps.AddRange(stage.jobs[0].steps);
                     else


### PR DESCRIPTION
Both flattening warnings, and the two matching rows in the conversion coverage table, referenced [#211](https://github.com/f2calv/yamlizr/pull/211).

That is a pull request, not an issue, and it cannot be merged: it predates the rename of `CasCap.Apis.AzureDevOps` to `CasCap.Api.AzureDevOps`, so the patch no longer applies to the tree. Pointing a runtime warning at a pull request that will be closed would leave users following a dead link.

The diagnosis in #211 is correct, and is now carried in [#376](https://github.com/f2calv/yamlizr/issues/376), which credits @dipaklazycoder and records the decision the fix implies: removing flattening changes the output of every single-job build definition, which is the common case.

No behaviour change, only the four references.